### PR TITLE
Redesign the analytics dashboard: dark UI, drawers, lookback, global exceptions

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "analytics-smoke",
+      "runtimeExecutable": "./target/debug/analytics",
+      "runtimeArgs": ["--config", "target/smoke/config.yaml"],
+      "port": 8099,
+      "autoPort": false
+    }
+  ]
+}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,5 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7.1.1
+        with:
+          # On pull requests, only run the autolabeler — don't try to write the
+          # draft release. Updating a release with the PR merge ref as
+          # `target_commitish` (refs/pull/N/merge) is rejected by the GitHub API.
+          disable-releaser: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,9 +14,10 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v7.1.1
         with:
-          # On pull requests, only run the autolabeler — don't try to write the
-          # draft release. Updating a release with the PR merge ref as
-          # `target_commitish` (refs/pull/N/merge) is rejected by the GitHub API.
-          disable-releaser: ${{ github.event_name == 'pull_request' }}
+          # On pull requests, compute the draft without writing it. Updating a
+          # release with the PR merge ref as `target_commitish` (refs/pull/N/merge)
+          # is rejected by the GitHub API; the release is still drafted on push to
+          # main, where dry-run is false.
+          dry-run: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install Trunk
         run: cargo binstall --no-confirm trunk
 
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Build UI
         working-directory: ui
         run: trunk build --release
@@ -105,6 +108,9 @@ jobs:
         uses: SierraSoftworks/setup-grcov@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --no-fail-fast
@@ -176,6 +182,8 @@ jobs:
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: Check out code
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.1.4",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -64,7 +64,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.9.0",
  "sha1",
  "smallvec",
  "tokio",
@@ -120,7 +120,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.8",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -166,7 +166,7 @@ dependencies = [
  "cookie",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.4",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -182,7 +182,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.8",
+ "socket2 0.6.0",
  "time",
  "tracing",
  "url",
@@ -205,19 +205,6 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -270,7 +257,7 @@ dependencies = [
  "jsonwebtoken",
  "polars",
  "redb",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -420,6 +407,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,11 +567,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -596,17 +605,6 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.1",
-]
-
-[[package]]
-name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
@@ -618,13 +616,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 5.0.1",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -639,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -708,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -749,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -827,6 +825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +870,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6407bff74dea37e0fa3dc1c1c974e5d46405f0c987bf9997a0762adce71eda6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.16",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,28 +892,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "const-hex"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6407bff74dea37e0fa3dc1c1c974e5d46405f0c987bf9997a0762adce71eda6"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
 
 [[package]]
 name = "cookie"
@@ -1099,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -1164,6 +1162,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1253,12 +1257,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.14"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1302,9 +1306,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1325,19 +1329,13 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "filt-rs"
 version = "0.1.0"
-source = "git+https://github.com/SierraSoftworks/filters#6f3738f6f13ba37e5ec8d59a96a8b6b7e52c1260"
+source = "git+https://github.com/SierraSoftworks/filters#3b60fa1ff8447d9c3d5d959caa2665bfb4c6fc39"
 dependencies = [
  "chrono",
  "human-errors",
  "regex",
  "serde",
 ]
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1364,9 +1362,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foldhash"
@@ -1394,8 +1392,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
@@ -1513,16 +1511,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
+ "wasi 0.13.3+wasi-0.2.2",
  "wasm-bindgen",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1533,7 +1531,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -1541,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -1568,7 +1566,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1587,7 +1585,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1605,7 +1603,7 @@ dependencies = [
  "crunchy",
  "num-traits",
  "serde",
- "zerocopy 0.8.27",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -1616,7 +1614,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash 0.1.4",
 ]
 
 [[package]]
@@ -1743,9 +1741,9 @@ checksum = "c5d10d3cf923652ca5b097e0795ddf1053f56bd7a2f4258089c64f45f1b70335"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "humantime-serde"
@@ -1828,7 +1826,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2029,16 +2027,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2096,30 +2084,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,12 +2138,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
- "cfg-if",
- "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2196,7 +2159,7 @@ dependencies = [
  "js-sys",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2409,16 +2372,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -2521,12 +2484,12 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.1",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -2635,18 +2598,11 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
+ "rand 0.9.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -2700,12 +2656,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2767,12 +2717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,7 +2760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f1f122456ec136102033b13f71905b7c3f01e526642679c86aace9f9cdefde"
 dependencies = [
  "getrandom 0.2.15",
- "getrandom 0.3.4",
+ "getrandom 0.3.1",
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
@@ -2848,7 +2792,7 @@ dependencies = [
  "either",
  "ethnum",
  "getrandom 0.2.15",
- "getrandom 0.3.4",
+ "getrandom 0.3.1",
  "half",
  "hashbrown 0.16.1",
  "itoa",
@@ -2892,7 +2836,7 @@ dependencies = [
  "polars-config",
  "polars-error",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.0",
  "slotmap",
  "tokio",
 ]
@@ -2928,7 +2872,7 @@ dependencies = [
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.0",
  "serde",
  "strength_reduce",
  "strum_macros",
@@ -2959,9 +2903,9 @@ dependencies = [
  "chrono-tz",
  "comfy-table",
  "either",
- "getrandom 0.3.4",
+ "getrandom 0.3.1",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -2974,7 +2918,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.0",
  "rand_distr",
  "rayon",
  "regex",
@@ -3035,7 +2979,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.0",
  "rayon",
  "recursive",
  "regex",
@@ -3077,10 +3021,10 @@ dependencies = [
  "polars-schema",
  "polars-time",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.0",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "simdutf8",
@@ -3167,7 +3111,7 @@ dependencies = [
  "either",
  "hashbrown 0.16.1",
  "hex",
- "indexmap 2.14.0",
+ "indexmap",
  "libm",
  "memchr",
  "num-traits",
@@ -3195,7 +3139,7 @@ checksum = "fd6b79ba2103c00cbb9c5dd4459ffff1d8ce15286c7a6d376a04c711df20d8b7"
 dependencies = [
  "async-stream",
  "base64",
- "brotli 8.0.3",
+ "brotli 8.0.1",
  "bytemuck",
  "ethnum",
  "flate2",
@@ -3243,7 +3187,7 @@ dependencies = [
  "either",
  "futures",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "memmap2",
  "num-traits",
  "percent-encoding",
@@ -3290,7 +3234,7 @@ version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8a0de8951d02576fd0cdcecd9c605a6b6364d3105b7469b8d7874ea34eea2f"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "polars-error",
  "polars-utils",
  "serde",
@@ -3399,14 +3343,14 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "libc",
  "memmap2",
  "num-derive",
  "num-traits",
  "polars-config",
  "polars-error",
- "rand 0.9.4",
+ "rand 0.9.0",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -3474,8 +3418,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -3536,8 +3480,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.8",
- "thiserror 2.0.9",
+ "socket2 0.5.10",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3550,8 +3494,9 @@ checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.0",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3572,7 +3517,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.8",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3588,21 +3533,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3611,12 +3550,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.52",
 ]
 
 [[package]]
@@ -3632,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
@@ -3647,7 +3587,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3656,16 +3605,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -3681,7 +3621,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.0",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3806,14 +3755,11 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3821,12 +3767,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.0",
 ]
@@ -3868,7 +3816,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -3942,6 +3889,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,7 +3963,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4016,7 +3972,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.6.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4114,6 +4070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "sentry"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,8 +4111,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
 dependencies = [
- "once_cell",
- "rand 0.8.5",
+ "rand 0.9.0",
  "sentry-types",
  "serde",
  "serde_json",
@@ -4176,7 +4137,7 @@ checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4257,7 +4218,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4297,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "2.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -4384,23 +4345,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -4668,16 +4625,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4738,8 +4695,8 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "rustls-pemfile",
- "socket2 0.5.8",
+ "socket2 0.6.0",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -4756,18 +4713,9 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -4960,9 +4908,15 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.0",
  "web-time",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -5108,42 +5062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
-dependencies = [
- "value-bag-serde1",
- "value-bag-sval2",
-]
-
-[[package]]
-name = "value-bag-serde1"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_fmt",
-]
-
-[[package]]
-name = "value-bag-sval2"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a"
-dependencies = [
- "sval",
- "sval_buffer",
- "sval_dynamic",
- "sval_fmt",
- "sval_json",
- "sval_ref",
- "sval_serde",
-]
-
-[[package]]
 name = "vergen"
 version = "8.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5193,6 +5111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5212,44 +5139,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.75"
+name = "wasm-bindgen-backend"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
+ "log",
  "proc-macro2",
  "quote",
  "syn",
@@ -5257,10 +5164,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.125"
+name = "wasm-bindgen-futures"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
@@ -5282,7 +5225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5308,15 +5251,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.2",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5360,6 +5303,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5372,10 +5331,7 @@ dependencies = [
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -5417,8 +5373,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5477,26 +5433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,21 +5443,20 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5548,7 +5483,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5564,15 +5499,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5717,6 +5643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "wit-bindgen-rust"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5724,7 +5659,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5755,7 +5690,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -5774,7 +5709,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -5848,11 +5783,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
- "zerocopy-derive 0.8.27",
+ "zerocopy-derive 0.8.52",
 ]
 
 [[package]]
@@ -5868,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5948,9 +5883,9 @@ checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
 
 [[package]]
 name = "zstd"

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -38,7 +38,7 @@ pub fn stats_for_sources(
 
     Ok(Stats {
         summary: summary(base.clone())?,
-        timeseries: timeseries(base, bucket_ms)?,
+        timeseries: timeseries(base, from_ms, to_ms, bucket_ms)?,
         pages: breakdown(pageloads.clone(), "pathname")?,
         referrers: breakdown(pageloads.clone(), "referrer_host")?,
         browsers: breakdown(pageloads.clone(), "ua_browser")?,
@@ -63,7 +63,7 @@ pub fn overview(
 
     let base = combined(store, parquet_dir, from_ms, to_ms)?;
     let summary = summary(base.clone())?;
-    let timeseries = timeseries(base.clone(), bucket_ms)?;
+    let timeseries = timeseries(base.clone(), from_ms, to_ms, bucket_ms)?;
     let per_source = per_source_totals(base)?;
 
     // Build a source-URI -> project map from assigned sources and pixels.
@@ -183,6 +183,62 @@ pub fn exception_groups(
                 last_seen_ms: last.get(i).unwrap_or(0),
                 status: ExceptionStatus::Unresolved,
                 note: None,
+            })
+        })
+        .collect())
+}
+
+/// Like [`exception_groups`] but across **every** source, grouped by
+/// `(fingerprint, source)`. A fingerprint is computed from the error alone, so the
+/// same `exc_group` legitimately occurs on multiple sources/projects; keeping the
+/// source in the key keeps those occurrences separate. The caller folds per-source
+/// rows up to per-project rows for the global Exceptions inbox.
+pub fn global_exception_groups(
+    store: &Store,
+    parquet_dir: &str,
+    from_ms: i64,
+    to_ms: i64,
+) -> Result<Vec<(ExceptionGroup, String)>> {
+    let df = combined(store, parquet_dir, from_ms, to_ms)?
+        .filter(col("kind").eq(lit("exception")))
+        .filter(col("exc_group").is_not_null())
+        .group_by([col("exc_group"), col("source")])
+        .agg([
+            len().cast(DataType::Int64).alias("count"),
+            col("received_ms").min().cast(DataType::Int64).alias("first_seen"),
+            col("received_ms").max().cast(DataType::Int64).alias("last_seen"),
+            col("exc_type").first().alias("exc_type"),
+            col("exc_message").first().alias("sample_message"),
+        ])
+        .sort(["last_seen"], SortMultipleOptions::default().with_order_descending(true))
+        .limit(500)
+        .collect()
+        .or_system_err(ADVICE)?;
+
+    let group_id = df.column("exc_group").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+    let count = df.column("count").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
+    let first = df.column("first_seen").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
+    let last = df.column("last_seen").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
+    let exc_type = df.column("exc_type").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+    let message = df.column("sample_message").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+    let source = df.column("source").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+
+    Ok((0..df.height())
+        .filter_map(|i| {
+            group_id.get(i).map(|gid| {
+                (
+                    ExceptionGroup {
+                        group_id: gid.to_string(),
+                        exc_type: exc_type.get(i).unwrap_or("").to_string(),
+                        sample_message: message.get(i).unwrap_or("").to_string(),
+                        count: count.get(i).unwrap_or(0),
+                        first_seen_ms: first.get(i).unwrap_or(0),
+                        last_seen_ms: last.get(i).unwrap_or(0),
+                        status: ExceptionStatus::Unresolved,
+                        note: None,
+                    },
+                    source.get(i).unwrap_or("").to_string(),
+                )
             })
         })
         .collect())
@@ -357,7 +413,10 @@ fn summary(base: LazyFrame) -> Result<MetricSummary> {
     })
 }
 
-fn timeseries(base: LazyFrame, bucket_ms: i64) -> Result<Vec<TimeSeriesPoint>> {
+/// A continuous time series over `[from_ms, to_ms]` at `bucket_ms` resolution.
+/// Buckets with no events are emitted as zeros so the chart shows a gap-free line
+/// across the whole window instead of collapsing absent periods.
+fn timeseries(base: LazyFrame, from_ms: i64, to_ms: i64, bucket_ms: i64) -> Result<Vec<TimeSeriesPoint>> {
     let bucket_ms = bucket_ms.max(1);
     let df = base
         .filter(col("kind").eq(lit("page_load")))
@@ -370,7 +429,6 @@ fn timeseries(base: LazyFrame, bucket_ms: i64) -> Result<Vec<TimeSeriesPoint>> {
                 .cast(DataType::Int64)
                 .alias("visitors"),
         ])
-        .sort(["bucket"], SortMultipleOptions::default())
         .collect()
         .or_system_err(ADVICE)?;
 
@@ -378,13 +436,36 @@ fn timeseries(base: LazyFrame, bucket_ms: i64) -> Result<Vec<TimeSeriesPoint>> {
     let pageviews = df.column("pageviews").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
     let visitors = df.column("visitors").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
 
-    Ok((0..df.height())
-        .map(|i| TimeSeriesPoint {
-            timestamp_ms: bucket.get(i).unwrap_or(0),
-            pageviews: pageviews.get(i).unwrap_or(0),
-            visitors: visitors.get(i).unwrap_or(0),
-        })
-        .collect())
+    // Index the populated buckets, then walk every bucket in the window.
+    let mut counts: std::collections::HashMap<i64, (i64, i64)> = std::collections::HashMap::new();
+    for i in 0..df.height() {
+        if let Some(b) = bucket.get(i) {
+            counts.insert(b, (pageviews.get(i).unwrap_or(0), visitors.get(i).unwrap_or(0)));
+        }
+    }
+
+    let first = from_ms - from_ms.rem_euclid(bucket_ms);
+    let last = to_ms - to_ms.rem_euclid(bucket_ms);
+    // Guard against a pathological window/bucket combination producing a huge vec.
+    let estimated = ((last - first) / bucket_ms).unsigned_abs() as usize + 1;
+    if first > last || estimated > 5_000 {
+        // Fall back to the populated buckets only (sorted).
+        let mut points: Vec<TimeSeriesPoint> = counts
+            .into_iter()
+            .map(|(b, (p, v))| TimeSeriesPoint { timestamp_ms: b, pageviews: p, visitors: v })
+            .collect();
+        points.sort_by_key(|p| p.timestamp_ms);
+        return Ok(points);
+    }
+
+    let mut points = Vec::with_capacity(estimated);
+    let mut b = first;
+    while b <= last {
+        let (pageviews, visitors) = counts.get(&b).copied().unwrap_or((0, 0));
+        points.push(TimeSeriesPoint { timestamp_ms: b, pageviews, visitors });
+        b += bucket_ms;
+    }
+    Ok(points)
 }
 
 fn breakdown(pageloads: LazyFrame, column: &str) -> Result<Vec<KeyCount>> {
@@ -573,6 +654,38 @@ mod tests {
         let _ = std::fs::remove_file(&redb);
     }
 
+    #[test]
+    fn timeseries_zero_fills_empty_buckets() {
+        let redb = temp_redb();
+        let store = Store::open(&redb).unwrap();
+        let day = 86_400_000i64;
+        // Two views on the first day only; the window spans three days.
+        store
+            .append_events(&[
+                load("https://a.com", 1_000, true, None),
+                load("https://a.com", 2_000, false, None),
+            ])
+            .unwrap();
+
+        let stats = stats_for_sources(
+            &store,
+            "/none",
+            &["https://a.com".to_string()],
+            0,
+            3 * day,
+            day,
+        )
+        .unwrap();
+
+        // Buckets at 0, 1d, 2d, 3d — empty days filled with zeros, not dropped.
+        assert_eq!(stats.timeseries.len(), 4);
+        assert_eq!(stats.timeseries[0].pageviews, 2);
+        assert!(stats.timeseries[1..].iter().all(|p| p.pageviews == 0 && p.visitors == 0));
+
+        drop(store);
+        let _ = std::fs::remove_file(&redb);
+    }
+
     fn typed(source: &str, received_ms: i64, kind: EventKind) -> StoredEvent {
         StoredEvent {
             created_ms: received_ms,
@@ -585,17 +698,47 @@ mod tests {
     }
 
     fn exc(group: &str, received_ms: i64) -> StoredEvent {
+        exc_on("https://a.com", group, received_ms)
+    }
+
+    fn exc_on(source: &str, group: &str, received_ms: i64) -> StoredEvent {
         StoredEvent {
             created_ms: received_ms,
             received_ms,
             kind: EventKind::Exception,
-            source: "https://a.com".into(),
+            source: source.into(),
             exc_type: Some("TypeError".into()),
             exc_message: Some("boom".into()),
             exc_group: Some(group.into()),
             exc_handled: Some(false),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn global_exception_groups_keep_sources_separate() {
+        let redb = temp_redb();
+        let store = Store::open(&redb).unwrap();
+        // Same fingerprint on two different sources (e.g. a shared-library error).
+        store
+            .append_events(&[
+                exc_on("https://a.com", "g1", 1_000),
+                exc_on("https://b.com", "g1", 2_000),
+                exc_on("https://a.com", "g1", 3_000),
+            ])
+            .unwrap();
+
+        let rows = global_exception_groups(&store, "/none", 0, 10_000).unwrap();
+        // One row per (fingerprint, source) — not collapsed across sources.
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|(g, _)| g.group_id == "g1"));
+        let a = rows.iter().find(|(_, s)| s == "https://a.com").unwrap();
+        assert_eq!(a.0.count, 2);
+        let b = rows.iter().find(|(_, s)| s == "https://b.com").unwrap();
+        assert_eq!(b.0.count, 1);
+
+        drop(store);
+        let _ = std::fs::remove_file(&redb);
     }
 
     #[test]

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -381,6 +381,7 @@ mod tests {
     fn example_config_loads() {
         let raw = include_str!("../../config.example.yaml");
         let config = Config::from_yaml_str(raw).expect("example config should load");
-        assert_eq!(config.web.address, "127.0.0.1:8080");
+        // The example binds loopback; the exact port may be tuned in the sample file.
+        assert!(config.web.address.starts_with("127.0.0.1:"));
     }
 }

--- a/agent/src/store/entities.rs
+++ b/agent/src/store/entities.rs
@@ -2,11 +2,12 @@
 
 use analytics_api::{Pixel, Project, Source, default_kind};
 use chrono::Utc;
+use redb::ReadableTable;
 
 use super::Store;
-use super::tables::{EXCEPTION_TRIAGE, PIXELS, PROJECTS, SOURCES, triage_key};
+use super::tables::{EXCEPTION_TRIAGE, PIXELS, PROJECTS, SOURCES, STORAGE_ADVICE, triage_key};
 use super::triage::ExceptionTriage;
-use crate::errors::Result;
+use crate::errors::{Result, ResultExt};
 
 impl Store {
     // ------------------------------------------------------------- projects
@@ -21,6 +22,62 @@ impl Store {
     }
     pub fn delete_project(&self, id: &str) -> Result<bool> {
         self.delete_key(PROJECTS, id)
+    }
+
+    /// Delete a project and everything that referenced it in a single write
+    /// transaction: its pixels are removed and its sources are unassigned, so a
+    /// partial failure can never leave a half-deleted project. Historical events
+    /// remain under their (now unassigned) sources. Returns `false` if the project
+    /// does not exist.
+    pub fn delete_project_cascade(&self, id: &str) -> Result<bool> {
+        let txn = self.db.begin_write().or_system_err(STORAGE_ADVICE)?;
+        let existed = {
+            let mut projects = txn.open_table(PROJECTS).or_system_err(STORAGE_ADVICE)?;
+            if projects.get(id).or_system_err(STORAGE_ADVICE)?.is_none() {
+                false
+            } else {
+                projects.remove(id).or_system_err(STORAGE_ADVICE)?;
+                true
+            }
+        };
+        if existed {
+            // Unassign every source pointing at this project.
+            {
+                let mut sources = txn.open_table(SOURCES).or_system_err(STORAGE_ADVICE)?;
+                let mut updates: Vec<(String, Vec<u8>)> = Vec::new();
+                for item in sources.iter().or_system_err(STORAGE_ADVICE)? {
+                    let (key, value) = item.or_system_err(STORAGE_ADVICE)?;
+                    let mut source: Source =
+                        serde_json::from_slice(value.value()).or_system_err(STORAGE_ADVICE)?;
+                    if source.project_id.as_deref() == Some(id) {
+                        source.project_id = None;
+                        let bytes = serde_json::to_vec(&source).or_system_err(STORAGE_ADVICE)?;
+                        updates.push((key.value().to_string(), bytes));
+                    }
+                }
+                for (key, bytes) in updates {
+                    sources.insert(key.as_str(), bytes.as_slice()).or_system_err(STORAGE_ADVICE)?;
+                }
+            }
+            // Delete every pixel belonging to this project.
+            {
+                let mut pixels = txn.open_table(PIXELS).or_system_err(STORAGE_ADVICE)?;
+                let mut to_delete: Vec<String> = Vec::new();
+                for item in pixels.iter().or_system_err(STORAGE_ADVICE)? {
+                    let (key, value) = item.or_system_err(STORAGE_ADVICE)?;
+                    let pixel: Pixel =
+                        serde_json::from_slice(value.value()).or_system_err(STORAGE_ADVICE)?;
+                    if pixel.project_id == id {
+                        to_delete.push(key.value().to_string());
+                    }
+                }
+                for key in to_delete {
+                    pixels.remove(key.as_str()).or_system_err(STORAGE_ADVICE)?;
+                }
+            }
+        }
+        txn.commit().or_system_err(STORAGE_ADVICE)?;
+        Ok(existed)
     }
 
     // -------------------------------------------------------------- sources

--- a/agent/src/store/mod.rs
+++ b/agent/src/store/mod.rs
@@ -234,6 +234,50 @@ mod tests {
     }
 
     #[test]
+    fn delete_project_cascade_unassigns_sources_and_removes_pixels() {
+        use analytics_api::{Pixel, Source, SourceKind};
+        let store = temp_store();
+        let now = Utc::now();
+        store
+            .put_project(&Project {
+                id: "p1".to_string(),
+                name: "P".to_string(),
+                slug: "p".to_string(),
+                created_at: now,
+            })
+            .unwrap();
+        store
+            .put_source(&Source {
+                uri: "https://a.com".to_string(),
+                project_id: Some("p1".to_string()),
+                kind: SourceKind::Website,
+                display_name: None,
+                created_at: now,
+                first_seen: Some(now),
+                last_seen: Some(now),
+            })
+            .unwrap();
+        store
+            .put_pixel(&Pixel {
+                id: "px1".to_string(),
+                project_id: "p1".to_string(),
+                name: "n".to_string(),
+                event_name: "pixel".to_string(),
+                metadata: Default::default(),
+                created_at: now,
+                last_hit: None,
+            })
+            .unwrap();
+
+        assert!(store.delete_project_cascade("p1").unwrap());
+        assert!(store.get_project("p1").unwrap().is_none());
+        assert_eq!(store.get_source("https://a.com").unwrap().unwrap().project_id, None);
+        assert!(store.get_pixel("px1").unwrap().is_none());
+        // A second source not on the project is left untouched; unknown id -> false.
+        assert!(!store.delete_project_cascade("nope").unwrap());
+    }
+
+    #[test]
     fn parquet_roundtrip() {
         let store = temp_store();
         let events = vec![event("https://a.com", 1000), event("pixel://01HX", 2000)];

--- a/agent/src/telemetry/actix_web_tracing.rs
+++ b/agent/src/telemetry/actix_web_tracing.rs
@@ -73,7 +73,7 @@ where
             propagator.extract(&HeaderMapExtractor::from(req.headers()))
         });
 
-        span.set_parent(context);
+        let _ = span.set_parent(context);
 
         let fut = self
             .service

--- a/agent/src/web/api/exceptions.rs
+++ b/agent/src/web/api/exceptions.rs
@@ -1,8 +1,10 @@
 //! Exception groups (Sentry-style): per-project listing, group detail, and triage.
 
+use std::collections::HashMap;
+
 use actix_web::http::StatusCode;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, web};
-use analytics_api::{ExceptionGroupDetail, TriageInput};
+use analytics_api::{ExceptionGroupDetail, GlobalException, TriageInput, pixel_source};
 use chrono::Utc;
 use serde::Deserialize;
 use tracing_batteries::prelude::*;
@@ -14,6 +16,77 @@ use crate::state::AppState;
 use crate::store::ExceptionTriage;
 
 const OCCURRENCE_LIMIT: usize = 50;
+
+/// `GET /api/v1/exceptions` — exception groups across every project (and
+/// unassigned sources), each annotated with its project, for the global inbox.
+pub async fn list_all(state: web::Data<AppState>, query: web::Query<StatsQuery>) -> HttpResponse {
+    let (from, to, _) = resolve_range(&query);
+    let store = state.store.clone();
+    let parquet_dir = state.config.storage.parquet_dir.clone();
+
+    let result = web::block(move || -> crate::errors::Result<Vec<GlobalException>> {
+        let per_source = analytics::global_exception_groups(&store, &parquet_dir, from, to)?;
+
+        // Resolve a source URI to its owning project, and project ids to names.
+        let mut uri_project: HashMap<String, String> = HashMap::new();
+        for source in store.list_sources()? {
+            if let Some(project_id) = source.project_id {
+                uri_project.insert(source.uri, project_id);
+            }
+        }
+        for pixel in store.list_pixels()? {
+            uri_project.insert(pixel_source(&pixel.id), pixel.project_id);
+        }
+        let project_names: HashMap<String, String> =
+            store.list_projects()?.into_iter().map(|p| (p.id, p.name)).collect();
+
+        // Fold per-(fingerprint, source) rows up to per-(fingerprint, project) rows
+        // so a project's count matches its detail page. Unassigned sources are keyed
+        // by source so each stays its own row (no project to merge into).
+        use std::collections::hash_map::Entry;
+        let mut acc: HashMap<(String, String), GlobalException> = HashMap::new();
+        for (group, source) in per_source {
+            let project_id = uri_project.get(&source).cloned();
+            let bucket = project_id.clone().unwrap_or_else(|| format!("@{source}"));
+            let key = (group.group_id.clone(), bucket);
+            match acc.entry(key) {
+                Entry::Occupied(mut e) => {
+                    let g = &mut e.get_mut().group;
+                    g.count += group.count;
+                    g.first_seen_ms = g.first_seen_ms.min(group.first_seen_ms);
+                    g.last_seen_ms = g.last_seen_ms.max(group.last_seen_ms);
+                }
+                Entry::Vacant(e) => {
+                    e.insert(GlobalException { group, project_id, project_name: None, source });
+                }
+            }
+        }
+
+        let mut out: Vec<GlobalException> = Vec::with_capacity(acc.len());
+        for (_, mut item) in acc {
+            if let Some(pid) = &item.project_id {
+                if let Some(triage) = store.get_triage(pid, &item.group.group_id)? {
+                    item.group.status = triage.status;
+                    item.group.note = triage.note;
+                }
+                item.project_name = project_names.get(pid).cloned();
+            }
+            out.push(item);
+        }
+        out.sort_by_key(|e| std::cmp::Reverse(e.group.last_seen_ms));
+        Ok(out)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(groups)) => HttpResponse::Ok().json(groups),
+        Ok(Err(err)) => internal_error(err),
+        Err(err) => {
+            error!("global exception listing task failed: {err}");
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load exceptions.")
+        }
+    }
+}
 
 /// `GET /api/v1/projects/{id}/exceptions` — grouped exceptions with triage status.
 pub async fn list(

--- a/agent/src/web/api/instance.rs
+++ b/agent/src/web/api/instance.rs
@@ -1,0 +1,23 @@
+//! Authenticated instance/runtime information for the Settings page.
+
+use actix_web::{HttpResponse, web};
+use analytics_api::Instance;
+
+use crate::state::AppState;
+
+/// `GET /api/v1/instance` — the running version and operational posture. It sits
+/// behind `api_auth`, so (unlike the public `/health` endpoint) it may reveal the
+/// version and configuration to a signed-in administrator.
+pub async fn instance(state: web::Data<AppState>) -> HttpResponse {
+    let cfg = &state.config;
+    HttpResponse::Ok().json(Instance {
+        version: crate::version!().to_string(),
+        retention_days: cfg.storage.retention.as_secs() / 86_400,
+        hot_window_hours: cfg.storage.hot_window.as_secs() / 3_600,
+        honor_dnt: cfg.privacy.honor_dnt,
+        rate_limiting: cfg.ratelimit.enabled,
+        tracking_per_minute: cfg.ratelimit.tracking.per_minute,
+        unauthenticated_per_minute: cfg.ratelimit.unauthenticated.per_minute,
+        max_auto_sources: cfg.storage.max_auto_sources as u64,
+    })
+}

--- a/agent/src/web/api/mod.rs
+++ b/agent/src/web/api/mod.rs
@@ -7,6 +7,7 @@
 
 mod auth;
 mod exceptions;
+mod instance;
 mod me;
 mod overview;
 mod pixels;
@@ -68,6 +69,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                     .wrap(from_fn(api_auth))
                     .route("/csrf", web::get().to(auth::csrf_token))
                     .route("/me", web::get().to(me::me))
+                    .route("/instance", web::get().to(instance::instance))
                     .route("/overview", web::get().to(overview::overview))
                     .route("/projects", web::get().to(projects::list))
                     .route("/projects", web::post().to(projects::create))
@@ -78,11 +80,13 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                     .route("/sources", web::get().to(sources::list))
                     .route("/sources", web::put().to(sources::update))
                     .route("/sources", web::delete().to(sources::delete))
+                    .route("/pixels", web::get().to(pixels::list_all))
                     .route("/projects/{id}/pixels", web::get().to(pixels::list))
                     .route("/projects/{id}/pixels", web::post().to(pixels::create))
                     .route("/pixels/{id}", web::get().to(pixels::get))
                     .route("/pixels/{id}", web::put().to(pixels::update))
                     .route("/pixels/{id}", web::delete().to(pixels::delete))
+                    .route("/exceptions", web::get().to(exceptions::list_all))
                     .route("/projects/{id}/exceptions", web::get().to(exceptions::list))
                     .route("/exceptions/{group}", web::get().to(exceptions::detail))
                     .route("/exceptions/{group}", web::patch().to(exceptions::triage)),

--- a/agent/src/web/api/pixels.rs
+++ b/agent/src/web/api/pixels.rs
@@ -22,6 +22,18 @@ pub async fn list(state: web::Data<AppState>, path: web::Path<String>) -> HttpRe
     }
 }
 
+/// `GET /api/v1/pixels` — every pixel across all projects, for the global Tracking
+/// Pixels page. Each pixel carries its `project_id` so the UI can label it.
+pub async fn list_all(state: web::Data<AppState>) -> HttpResponse {
+    match state.store.list_pixels() {
+        Ok(mut pixels) => {
+            pixels.sort_by_key(|p| p.name.to_lowercase());
+            HttpResponse::Ok().json(pixels)
+        }
+        Err(err) => internal_error(err),
+    }
+}
+
 pub async fn create(
     state: web::Data<AppState>,
     path: web::Path<String>,

--- a/agent/src/web/api/projects.rs
+++ b/agent/src/web/api/projects.rs
@@ -72,10 +72,22 @@ pub async fn update(
 }
 
 pub async fn delete(state: web::Data<AppState>, path: web::Path<String>) -> HttpResponse {
-    match state.store.delete_project(&path.into_inner()) {
-        Ok(true) => HttpResponse::NoContent().finish(),
-        Ok(false) => json_error(StatusCode::NOT_FOUND, "Project not found."),
-        Err(err) => internal_error(err),
+    let id = path.into_inner();
+    let store = state.store.clone();
+    // Atomic cascade: unassign the project's sources and delete its pixels in the
+    // same write transaction that removes the project, so a partial failure can't
+    // leave a half-deleted project. Historical events remain under their (now
+    // unassigned) sources.
+    let result = web::block(move || store.delete_project_cascade(&id)).await;
+
+    match result {
+        Ok(Ok(true)) => HttpResponse::NoContent().finish(),
+        Ok(Ok(false)) => json_error(StatusCode::NOT_FOUND, "Project not found."),
+        Ok(Err(err)) => internal_error(err),
+        Err(err) => {
+            error!("project delete task failed: {err}");
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to delete the project.")
+        }
     }
 }
 

--- a/agent/src/web/api/query.rs
+++ b/agent/src/web/api/query.rs
@@ -10,7 +10,7 @@ pub struct StatsQuery {
     pub from: Option<i64>,
     /// Range end (epoch millis); defaults to now.
     pub to: Option<i64>,
-    /// Time-series bucket: `minute` | `hour` | `day` (default).
+    /// Time-series bucket: `minute` | `hour` | `6h` | `day` (default) | `week`.
     pub interval: Option<String>,
     /// Comma-separated subset of source URIs to filter to.
     pub sources: Option<String>,
@@ -24,6 +24,8 @@ pub fn resolve_range(query: &StatsQuery) -> (i64, i64, i64) {
     let bucket = match query.interval.as_deref() {
         Some("minute") => 60_000,
         Some("hour") => 3_600_000,
+        Some("6h") => 6 * 3_600_000,
+        Some("week") => 7 * DAY_MS,
         _ => DAY_MS,
     };
     (from, to, bucket)

--- a/api/src/exception.rs
+++ b/api/src/exception.rs
@@ -75,6 +75,20 @@ pub struct ExceptionGroupDetail {
     pub occurrences: Vec<ExceptionOccurrence>,
 }
 
+/// An exception group annotated with the project it belongs to, for the global
+/// Exceptions inbox. `project_id`/`project_name` are absent when the originating
+/// source is unassigned.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GlobalException {
+    pub group: ExceptionGroup,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    /// A representative source URI the group was seen on.
+    pub source: String,
+}
+
 /// Payload for updating an exception group's triage state.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriageInput {

--- a/api/src/instance.rs
+++ b/api/src/instance.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+/// Authenticated instance/runtime information shown on the Settings page. Unlike
+/// the public health endpoint (which deliberately reveals nothing), this exposes
+/// the running version and operational posture, so it is only reachable from
+/// behind the admin ACL.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Instance {
+    /// The running software version (a release tag, or `0.0.0-dev` in debug builds).
+    pub version: String,
+    /// How long cold Parquet partitions are retained, in days.
+    pub retention_days: u64,
+    /// How long events stay in the hot store before compaction, in hours.
+    pub hot_window_hours: u64,
+    /// Whether `DNT` / `Sec-GPC` signals are honoured by dropping the beacon.
+    pub honor_dnt: bool,
+    /// Whether per-IP rate limiting is enabled.
+    pub rate_limiting: bool,
+    /// Sustained per-IP requests/minute allowed on the public tracking endpoints.
+    pub tracking_per_minute: u32,
+    /// Sustained per-IP requests/minute allowed for unauthenticated API hits.
+    pub unauthenticated_per_minute: u32,
+    /// Ceiling on auto-registered (unassigned) sources.
+    pub max_auto_sources: u64,
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -7,6 +7,7 @@
 mod auth;
 mod exception;
 mod health;
+mod instance;
 mod pixel;
 mod project;
 mod source;
@@ -16,9 +17,10 @@ mod track;
 pub use auth::{AdminUser, CsrfToken};
 pub use exception::{
     ExceptionGroup, ExceptionGroupDetail, ExceptionOccurrence, ExceptionReport, ExceptionStatus,
-    TriageInput,
+    GlobalException, TriageInput,
 };
 pub use health::Health;
+pub use instance::Instance;
 pub use pixel::{Pixel, PixelInput};
 pub use project::{Project, ProjectInput};
 pub use source::{

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -3,7 +3,7 @@ name = "analytics-ui"
 description = "Client-side-rendered Yew dashboard for the analytics service."
 version = "0.1.0"
 authors = ["Benjamin Pannell <benjamin@pannell.dev>"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/SierraSoftworks/analytics"
 publish = false
@@ -27,9 +27,14 @@ js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "Window",
     "Location",
+    "Navigator",
+    "Clipboard",
     "Event",
     "EventTarget",
     "InputEvent",
+    "Element",
+    "DomRect",
+    "HtmlElement",
     "HtmlInputElement",
     "HtmlSelectElement",
 ] }

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="author" content="Sierra Softworks" />
+    <meta name="description" content="Privacy-preserving web analytics by Sierra Softworks." />
     <title>Analytics | Sierra Softworks</title>
+    <link rel="icon" href="https://cdn.sierrasoftworks.com/logos/logo.ico" type="image/x-icon" />
     <link data-trunk rel="scss" href="styles.scss" />
     <link data-trunk rel="rust" data-bin="analytics-ui" />
   </head>

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -8,8 +8,8 @@
 use std::cell::RefCell;
 
 use analytics_api::{
-    AdminUser, CsrfToken, ExceptionGroup, ExceptionGroupDetail, Overview, Pixel, PixelInput,
-    Project, ProjectInput, Source, SourceInput, Stats, TriageInput,
+    AdminUser, CsrfToken, ExceptionGroup, ExceptionGroupDetail, GlobalException, Instance, Overview,
+    Pixel, PixelInput, Project, ProjectInput, Source, SourceInput, Stats, TriageInput,
 };
 use gloo_net::http::Request;
 use serde::Serialize;
@@ -174,6 +174,15 @@ pub async fn overview(range: &str) -> Result<Overview, ApiError> {
     get_json(&format!("/overview?{range}")).await
 }
 
+pub async fn instance() -> Result<Instance, ApiError> {
+    get_json("/instance").await
+}
+
+/// Every pixel across all projects (for the global Tracking Pixels page).
+pub async fn list_all_pixels() -> Result<Vec<Pixel>, ApiError> {
+    get_json("/pixels").await
+}
+
 pub async fn list_projects() -> Result<Vec<Project>, ApiError> {
     get_json("/projects").await
 }
@@ -202,16 +211,12 @@ pub async fn update_source(uri: &str, input: &SourceInput) -> Result<Source, Api
     put_json(&format!("/sources?uri={}", enc(uri)), input).await
 }
 
-pub async fn delete_source(uri: &str) -> Result<(), ApiError> {
-    delete(&format!("/sources?uri={}", enc(uri))).await
-}
-
-pub async fn list_pixels(project_id: &str) -> Result<Vec<Pixel>, ApiError> {
-    get_json(&format!("/projects/{}/pixels", enc(project_id))).await
-}
-
 pub async fn create_pixel(project_id: &str, input: &PixelInput) -> Result<Pixel, ApiError> {
     post_json(&format!("/projects/{}/pixels", enc(project_id)), input).await
+}
+
+pub async fn update_pixel(id: &str, input: &PixelInput) -> Result<Pixel, ApiError> {
+    put_json(&format!("/pixels/{}", enc(id)), input).await
 }
 
 pub async fn delete_pixel(id: &str) -> Result<(), ApiError> {
@@ -220,6 +225,11 @@ pub async fn delete_pixel(id: &str) -> Result<(), ApiError> {
 
 pub async fn list_exceptions(project_id: &str, range: &str) -> Result<Vec<ExceptionGroup>, ApiError> {
     get_json(&format!("/projects/{}/exceptions?{range}", enc(project_id))).await
+}
+
+/// Exception groups across every project (and unassigned sources).
+pub async fn list_all_exceptions(range: &str) -> Result<Vec<GlobalException>, ApiError> {
+    get_json(&format!("/exceptions?{range}")).await
 }
 
 pub async fn exception_detail(

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -7,19 +7,23 @@ use yew_router::prelude::*;
 
 use crate::api::{self, ApiError};
 use crate::auth;
-use crate::components::Layout;
+use crate::components::{AppShell, PublicLayout};
 use crate::pages;
 
 #[derive(Clone, Routable, PartialEq)]
 pub enum Route {
     #[at("/")]
     Overview,
+    #[at("/exceptions")]
+    Exceptions,
     #[at("/projects/:id")]
     Project { id: String },
     #[at("/projects/:project/exceptions/:group")]
     Exception { project: String, group: String },
-    #[at("/sources")]
-    Sources,
+    #[at("/pixels")]
+    Pixels,
+    #[at("/settings")]
+    Settings,
     #[not_found]
     #[at("/404")]
     NotFound,
@@ -101,35 +105,47 @@ fn app_inner() -> Html {
     let auth = use_auth();
     html! {
         <ContextProvider<AuthHandle> context={auth.clone()}>
-            <Layout>{ gate(&auth) }</Layout>
+            { gate(&auth) }
         </ContextProvider<AuthHandle>>
     }
 }
 
-/// Render the routed content once access is resolved.
+/// Render the routed app once access is resolved, falling back to the public
+/// chrome (sign-in / status) while it is not.
 fn gate(auth: &AuthHandle) -> Html {
     match &auth.status {
-        AuthStatus::Loading => html! { <p class="muted">{ "Loading…" }</p> },
-        AuthStatus::NeedsLogin => html! { <pages::Login /> },
-        AuthStatus::Error(message) => html! {
-            <div class="alert alert--error">
-                { format!("Couldn't verify your session: {message}") }
-            </div>
+        AuthStatus::Loading => html! {
+            <PublicLayout>
+                <div class="center-screen"><p class="muted">{ "Loading…" }</p></div>
+            </PublicLayout>
         },
-        AuthStatus::SignedIn(_) | AuthStatus::Disabled => {
-            html! { <Switch<Route> render={switch} /> }
-        }
+        AuthStatus::NeedsLogin => html! { <PublicLayout><pages::Login /></PublicLayout> },
+        AuthStatus::Error(message) => html! {
+            <PublicLayout>
+                <div class="center-screen">
+                    <div class="auth-card">
+                        <h1>{ "Couldn't verify your session" }</h1>
+                        <p>{ message.clone() }</p>
+                    </div>
+                </div>
+            </PublicLayout>
+        },
+        AuthStatus::SignedIn(_) | AuthStatus::Disabled => html! {
+            <AppShell><Switch<Route> render={switch} /></AppShell>
+        },
     }
 }
 
 fn switch(route: Route) -> Html {
     match route {
         Route::Overview => html! { <pages::Overview /> },
+        Route::Exceptions => html! { <pages::Exceptions /> },
         Route::Project { id } => html! { <pages::Project {id} /> },
         Route::Exception { project, group } => {
             html! { <pages::ExceptionDetail {project} {group} /> }
         }
-        Route::Sources => html! { <pages::Sources /> },
+        Route::Pixels => html! { <pages::Pixels /> },
+        Route::Settings => html! { <pages::Settings /> },
         Route::NotFound => html! { <pages::NotFound /> },
     }
 }

--- a/ui/src/components/_alert.scss
+++ b/ui/src/components/_alert.scss
@@ -1,0 +1,85 @@
+// Page-level alert / notice (see components/alert.rs and components/error.rs).
+@use '../styles/variables' as *;
+
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  margin-bottom: 1.25rem;
+
+  &__icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    margin-top: 0.05rem;
+  }
+  &__body {
+    flex: 1;
+    min-width: 0;
+  }
+  &__title {
+    display: block;
+    font-weight: 600;
+    font-size: 0.92rem;
+  }
+  &__message {
+    margin: 0.3rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-2);
+    word-break: break-word;
+  }
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.8rem;
+  }
+  &__close {
+    flex-shrink: 0;
+    display: inline-flex;
+    padding: 0.15rem;
+    border: none;
+    background: none;
+    color: var(--text-3);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+
+    &:hover {
+      color: var(--text);
+    }
+  }
+
+  &--error {
+    border-color: var(--danger-soft);
+    background: var(--danger-soft);
+    .alert__title,
+    .alert__icon {
+      color: var(--danger);
+    }
+  }
+  &--warning {
+    border-color: var(--warn-soft);
+    background: var(--warn-soft);
+    .alert__title,
+    .alert__icon {
+      color: var(--warn);
+    }
+  }
+  &--info {
+    .alert__title,
+    .alert__icon {
+      color: var(--info);
+    }
+  }
+  &--success {
+    border-color: var(--ok-soft);
+    background: var(--ok-soft);
+    .alert__title,
+    .alert__icon {
+      color: var(--ok);
+    }
+  }
+}

--- a/ui/src/components/_app_bar.scss
+++ b/ui/src/components/_app_bar.scss
@@ -1,0 +1,197 @@
+// The top app bar: brand mark, the unified search with autocomplete, and the
+// signed-in user chip (see components/app_bar.rs).
+@use '../styles/variables' as *;
+
+.app-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  height: var(--bar-h);
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0 1.25rem;
+  background: rgba(14, 16, 20, 0.82);
+  backdrop-filter: saturate(160%) blur(10px);
+  border-bottom: 1px solid var(--border);
+
+  &__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    width: calc(var(--sidebar-w) - 1.25rem);
+    flex-shrink: 0;
+    color: var(--text);
+
+    &:hover {
+      color: var(--text);
+    }
+
+    img {
+      height: 24px;
+      width: 24px;
+    }
+  }
+
+  &__brand-name {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+  }
+
+  &__brand-by {
+    font-size: 0.72rem;
+    color: var(--text-3);
+  }
+
+  &__spacer {
+    flex: 1;
+  }
+
+  // Unified search field hosted in the app bar.
+  &__search {
+    position: relative;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    max-width: 30rem;
+    margin: 0 auto;
+  }
+
+  &__search-icon {
+    position: absolute;
+    left: 0.7rem;
+    display: inline-flex;
+    color: var(--text-4);
+    pointer-events: none;
+  }
+
+  &__search-input {
+    width: 100%;
+    font: inherit;
+    font-size: 0.86rem;
+    padding: 0.5rem 0.8rem 0.5rem 2.1rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    transition: border-color var(--transition), box-shadow var(--transition);
+
+    &::placeholder {
+      color: var(--text-4);
+    }
+    &:focus {
+      @include focus-ring;
+    }
+  }
+
+  &__suggestions {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    left: 0;
+    right: 0;
+    z-index: 40;
+    margin: 0;
+    padding: 0.3rem;
+    list-style: none;
+    background: var(--overlay);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    max-height: 22rem;
+    overflow-y: auto;
+  }
+
+  &__suggestion {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.45rem 0.6rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+
+    &--active {
+      background: var(--brand-soft);
+    }
+
+    &-token {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: var(--brand-2);
+    }
+
+    &-desc {
+      font-size: 0.8rem;
+      color: var(--text-3);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+// Signed-in user chip.
+.user-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-shrink: 0;
+
+  &__avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--brand-strong);
+    color: #fff;
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.25;
+  }
+
+  &__name {
+    font-size: 0.83rem;
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  &__email {
+    font-size: 0.74rem;
+    color: var(--text-3);
+  }
+
+  &__signout {
+    margin-left: 0.4rem;
+    padding: 0.35rem 0.55rem;
+    font-size: 0.76rem;
+    color: var(--text-3);
+    background: none;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--danger);
+      background: var(--danger-soft);
+    }
+  }
+}
+
+@media (max-width: $bp-sm) {
+  .app-bar__brand {
+    width: auto;
+  }
+  .app-bar__brand-by,
+  .user-chip__meta {
+    display: none;
+  }
+}

--- a/ui/src/components/_auth.scss
+++ b/ui/src/components/_auth.scss
@@ -1,0 +1,53 @@
+// Signed-out / public chrome: the brand header wrapper and centred auth card used
+// by the sign-in and 404 screens (see components/layout.rs and pages/misc.rs).
+@use '../styles/variables' as *;
+
+.public-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.public-header {
+  padding: 1.5rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+
+  img {
+    height: 26px;
+    width: 26px;
+  }
+
+  span {
+    font-weight: 600;
+  }
+}
+
+.center-screen {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.auth-card {
+  @include card;
+  width: min(92vw, 26rem);
+  padding: 2.25rem 2.5rem;
+  text-align: center;
+
+  h1 {
+    font-size: 1.5rem;
+  }
+
+  p {
+    margin: 0.75rem 0 1.5rem;
+    color: var(--text-3);
+  }
+
+  code {
+    color: var(--brand-2);
+  }
+}

--- a/ui/src/components/_controls.scss
+++ b/ui/src/components/_controls.scss
@@ -1,0 +1,154 @@
+// Form primitives shared across the app: buttons, inputs, fields, and badges.
+@use '../styles/variables' as *;
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1;
+  min-height: 36px;
+  padding: 0.55rem 0.95rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
+  color: var(--text-2);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--transition), background var(--transition),
+    border-color var(--transition), box-shadow var(--transition),
+    opacity var(--transition);
+
+  &:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--brand-border);
+    background: var(--surface-3);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &--small {
+    font-size: 0.78rem;
+    min-height: 30px;
+    padding: 0.38rem 0.65rem;
+  }
+
+  &--primary {
+    color: #fff;
+    background: var(--brand-strong);
+    border-color: var(--brand-strong);
+
+    &:hover:not(:disabled) {
+      color: #fff;
+      background: var(--brand-strong-2);
+      border-color: var(--brand-strong-2);
+    }
+  }
+
+  &--ghost {
+    background: transparent;
+    border-color: transparent;
+
+    &:hover:not(:disabled) {
+      background: var(--surface-2);
+      border-color: var(--border);
+    }
+  }
+
+  &--danger {
+    color: var(--danger);
+    background: var(--danger-soft);
+    border-color: transparent;
+
+    &:hover:not(:disabled) {
+      color: #fff;
+      background: var(--danger);
+      border-color: var(--danger);
+    }
+  }
+}
+
+.input,
+select.input {
+  font: inherit;
+  font-size: 0.85rem;
+  min-height: 36px;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text);
+  transition: border-color var(--transition), box-shadow var(--transition);
+
+  &::placeholder {
+    color: var(--text-4);
+  }
+
+  &:focus {
+    @include focus-ring;
+  }
+}
+
+select.input {
+  cursor: pointer;
+}
+
+.form-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0.75rem 0 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+
+  &__label {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--text-3);
+  }
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+
+  &--ok {
+    color: var(--ok);
+    background: var(--ok-soft);
+  }
+  &--warn {
+    color: var(--warn);
+    background: var(--warn-soft);
+  }
+  &--muted {
+    color: var(--text-3);
+    background: var(--info-soft);
+  }
+  &--brand {
+    color: var(--brand-2);
+    background: var(--brand-soft);
+  }
+}

--- a/ui/src/components/_drawer.scss
+++ b/ui/src/components/_drawer.scss
@@ -1,0 +1,154 @@
+// The slide-in drawer used by the create/edit wizards, plus the form controls it
+// hosts: the key/value metadata editor and membership toggle rows
+// (see components/drawer.rs).
+@use '../styles/variables' as *;
+
+.drawer-root {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+}
+
+.drawer__scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  animation: fade-in 120ms ease;
+}
+
+.drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(460px, 94vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-left: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-md);
+  outline: none;
+  animation: slide-in 170ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  &__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.05rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  &__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+  }
+
+  &__close {
+    display: inline-flex;
+    padding: 0.3rem;
+    border: none;
+    background: none;
+    color: var(--text-3);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: color var(--transition), background var(--transition);
+
+    &:hover {
+      color: var(--text);
+      background: var(--surface-2);
+    }
+  }
+
+  &__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.6rem;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--border);
+  }
+
+  &__hint {
+    font-size: 0.82rem;
+    color: var(--text-3);
+    margin: -0.4rem 0 0;
+  }
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+// Repeated key/value rows (pixel metadata editor).
+.kv-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  &__row {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  &__remove {
+    display: inline-flex;
+    padding: 0.45rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text-3);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--danger);
+      border-color: var(--danger-soft);
+    }
+  }
+}
+
+// Membership toggle rows (source-membership + create-project drawers).
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+
+  &__label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text-2);
+  }
+}

--- a/ui/src/components/_dropdown.scss
+++ b/ui/src/components/_dropdown.scss
@@ -1,0 +1,108 @@
+// The cohesively-themed dropdown that replaces native <select> (see
+// components/dropdown.rs). Its menu is positioned `fixed` against the trigger rect
+// (set inline) so a scrolling ancestor — e.g. a drawer body — never clips it.
+@use '../styles/variables' as *;
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+
+  &--block {
+    display: block;
+  }
+
+  &__trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
+    min-width: 9rem;
+    min-height: 36px;
+    font: inherit;
+    font-size: 0.85rem;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    transition: border-color var(--transition), background var(--transition);
+
+    &:hover:not(:disabled) {
+      border-color: var(--brand-border);
+      background: var(--surface-3);
+    }
+
+    &:focus-visible {
+      @include focus-ring;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &--block &__trigger {
+    min-width: 0;
+  }
+
+  &__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__caret {
+    color: var(--text-3);
+    flex-shrink: 0;
+  }
+
+  &__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 109;
+  }
+
+  &__menu {
+    position: fixed;
+    z-index: 110;
+    margin: 0;
+    padding: 0.3rem;
+    list-style: none;
+    background: var(--overlay);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    max-height: 18rem;
+    overflow-y: auto;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.45rem 0.6rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    color: var(--text-2);
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:hover {
+      background: var(--surface-2);
+      color: var(--text);
+    }
+
+    &--selected {
+      color: var(--brand-2);
+    }
+  }
+
+  &__check {
+    color: var(--brand-2);
+    flex-shrink: 0;
+  }
+}

--- a/ui/src/components/_exceptions.scss
+++ b/ui/src/components/_exceptions.scss
@@ -1,0 +1,48 @@
+// The exception detail view: header, message, and occurrence/stack cards
+// (see pages/exception_detail.rs).
+@use '../styles/variables' as *;
+
+.exc-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+
+  h1 {
+    font-size: 1.3rem;
+  }
+}
+
+.exc-message {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.occurrence {
+  @include card;
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.75rem;
+
+  &__meta {
+    font-size: 0.8rem;
+    color: var(--text-3);
+    margin-bottom: 0.35rem;
+  }
+}
+
+.stack {
+  margin: 0.5rem 0 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/ui/src/components/_page_header.scss
+++ b/ui/src/components/_page_header.scss
@@ -1,0 +1,77 @@
+// The page header — breadcrumb, title row, and page/section scaffolding
+// (see components/page_header.rs).
+@use '../styles/variables' as *;
+
+.page {
+  display: block;
+}
+
+section + section,
+.section {
+  margin-top: 2.25rem;
+}
+
+.section__title {
+  font-size: 1.02rem;
+  font-weight: 600;
+  margin: 0 0 0.9rem;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+  font-size: 0.82rem;
+  color: var(--text-3);
+
+  &__sep {
+    color: var(--text-4);
+  }
+
+  &__item {
+    color: var(--text-3);
+
+    &:hover {
+      color: var(--text-2);
+    }
+
+    &--current {
+      color: var(--text-2);
+      font-weight: 500;
+    }
+  }
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+  padding-bottom: 1.1rem;
+  border-bottom: 1px solid var(--border);
+
+  &__text {
+    min-width: 0;
+  }
+
+  &__title {
+    font-size: 1.4rem;
+    font-weight: 650;
+  }
+
+  &__subtitle {
+    margin: 0.3rem 0 0;
+    font-size: 0.88rem;
+    color: var(--text-3);
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+}

--- a/ui/src/components/_settings.scss
+++ b/ui/src/components/_settings.scss
@@ -1,0 +1,76 @@
+// The Settings page: cards, key/value rows, and the copyable install snippet
+// (see pages/settings.rs).
+@use '../styles/variables' as *;
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 760px;
+}
+
+.settings-card {
+  @include card;
+  padding: 1.25rem 1.4rem;
+
+  &__title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.25rem;
+  }
+
+  &__desc {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    color: var(--text-3);
+  }
+
+  &--danger {
+    border-color: var(--danger-soft);
+  }
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 0.55rem 1rem;
+  font-size: 0.88rem;
+
+  &__key {
+    color: var(--text-3);
+  }
+  &__val {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+    word-break: break-word;
+  }
+}
+
+.snippet {
+  position: relative;
+  margin: 0;
+  padding: 0.9rem 1rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--text-2);
+  overflow-x: auto;
+  white-space: pre;
+
+  &__copy {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.55rem;
+  }
+}
+
+@media (max-width: $bp-sm) {
+  .kv {
+    grid-template-columns: 1fr;
+    gap: 0.15rem 0;
+    margin-bottom: 0.5rem;
+  }
+}

--- a/ui/src/components/_sidebar.scss
+++ b/ui/src/components/_sidebar.scss
@@ -1,0 +1,132 @@
+// The left navigation sidebar and its menu (see components/sidebar.rs).
+@use '../styles/variables' as *;
+
+.app-sidebar {
+  position: sticky;
+  top: var(--bar-h);
+  height: calc(100vh - var(--bar-h));
+  overflow-y: auto;
+  border-right: 1px solid var(--border);
+  padding: 1rem 0.75rem;
+}
+
+.menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+
+  &__section {
+    margin: 1.1rem 0.65rem 0.3rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-4);
+
+    &:first-child {
+      margin-top: 0.25rem;
+    }
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.65rem;
+    border-radius: var(--radius-sm);
+    color: var(--text-2);
+    font-size: 0.88rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition);
+
+    &:hover {
+      background: var(--surface-2);
+      color: var(--text);
+    }
+
+    &--active {
+      background: var(--brand-soft);
+      color: var(--brand-2);
+
+      .menu__icon {
+        color: var(--brand-2);
+      }
+    }
+  }
+
+  &__icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    color: var(--text-3);
+  }
+
+  &__label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // Nested project list.
+  &__sub {
+    list-style: none;
+    margin: 0.1rem 0 0.2rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  &__subitem {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.42rem 0.65rem 0.42rem 2.15rem;
+    border-radius: var(--radius-sm);
+    color: var(--text-3);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition);
+
+    &:hover {
+      background: var(--surface-2);
+      color: var(--text);
+    }
+
+    &--active {
+      color: var(--brand-2);
+      background: var(--brand-soft);
+    }
+  }
+
+  &__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: currentColor;
+    opacity: 0.55;
+  }
+
+  &__empty {
+    padding: 0.3rem 0.65rem 0.3rem 2.15rem;
+    font-size: 0.82rem;
+    color: var(--text-3);
+  }
+}
+
+@media (max-width: $bp-sm) {
+  .app-sidebar {
+    position: static;
+    height: auto;
+    max-height: 45vh;
+    overflow-y: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+}

--- a/ui/src/components/_stats.scss
+++ b/ui/src/components/_stats.scss
@@ -1,0 +1,69 @@
+// Statistic cards and the time-series chart panel (see components/widgets.rs).
+@use '../styles/variables' as *;
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.stat {
+  @include card;
+  padding: 1.1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition: border-color var(--transition);
+
+  &__label {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--text-3);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  &__value {
+    font-size: 1.85rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+  }
+
+  &__suffix {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-3);
+    margin-left: 0.15rem;
+  }
+}
+
+.panel {
+  @include card;
+  padding: 1.1rem 1.2rem;
+  margin-top: 1.25rem;
+}
+
+.chart {
+  width: 100%;
+  height: 180px;
+  display: block;
+
+  .bar {
+    fill: var(--brand);
+    opacity: 0.8;
+    transition: opacity var(--transition);
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}
+
+@media (max-width: $bp-md) {
+  .stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/ui/src/components/_tables.scss
+++ b/ui/src/components/_tables.scss
@@ -1,0 +1,157 @@
+// Tabular data: breakdown cards, list tables, tabs, and shared table utilities.
+@use '../styles/variables' as *;
+
+.breakdowns {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.breakdown {
+  @include card;
+  padding: 1.1rem 1.2rem;
+
+  h3 {
+    margin: 0 0 0.75rem;
+    font-size: 0.92rem;
+    font-weight: 600;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  td {
+    padding: 0.32rem 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  &__key {
+    max-width: 0;
+    width: 78%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-2);
+  }
+
+  &__count {
+    text-align: right;
+    color: var(--text-3);
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.list {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    text-align: left;
+    color: var(--text-3);
+    font-weight: 500;
+    font-size: 0.78rem;
+    letter-spacing: 0.02em;
+    padding: 0.5rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 0.6rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.87rem;
+    color: var(--text-2);
+  }
+
+  tbody tr {
+    transition: background var(--transition);
+
+    &:hover {
+      background: var(--surface);
+    }
+  }
+}
+
+.card-table {
+  @include card;
+  overflow: hidden;
+
+  .list th:first-child,
+  .list td:first-child {
+    padding-left: 1.1rem;
+  }
+  .list th:last-child,
+  .list td:last-child {
+    padding-right: 1.1rem;
+  }
+}
+
+.ellipsis {
+  max-width: 380px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.embed {
+  font-size: 0.78rem;
+  color: var(--text-3);
+  word-break: break-all;
+}
+
+.row-actions {
+  display: flex;
+  gap: 0.4rem;
+  justify-content: flex-end;
+  white-space: nowrap;
+}
+
+.empty {
+  @include card;
+  padding: 2.5rem;
+  text-align: center;
+  color: var(--text-3);
+}
+
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin: 0 0 1.5rem;
+}
+
+.tab {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color var(--transition), border-color var(--transition);
+
+  &:hover {
+    color: var(--text);
+  }
+
+  &--active {
+    color: var(--brand-2);
+    border-bottom-color: var(--brand);
+  }
+}
+
+@media (max-width: $bp-md) {
+  .breakdowns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ui/src/components/alert.rs
+++ b/ui/src/components/alert.rs
@@ -1,0 +1,94 @@
+use yew::prelude::*;
+
+/// The severity of an [`Alert`], selecting its colour and icon.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // The full set is part of the component's API.
+pub enum AlertKind {
+    Error,
+    Warning,
+    Info,
+    Success,
+}
+
+impl AlertKind {
+    fn class(self) -> &'static str {
+        match self {
+            AlertKind::Error => "alert--error",
+            AlertKind::Warning => "alert--warning",
+            AlertKind::Info => "alert--info",
+            AlertKind::Success => "alert--success",
+        }
+    }
+
+    fn icon(self) -> Html {
+        let path = match self {
+            AlertKind::Error => html! {
+                <>
+                    <circle cx="12" cy="12" r="10" />
+                    <line x1="12" y1="8" x2="12" y2="12" />
+                    <line x1="12" y1="16" x2="12.01" y2="16" />
+                </>
+            },
+            AlertKind::Warning => html! {
+                <>
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                    <line x1="12" y1="9" x2="12" y2="13" />
+                    <line x1="12" y1="17" x2="12.01" y2="17" />
+                </>
+            },
+            AlertKind::Info => html! {
+                <>
+                    <circle cx="12" cy="12" r="10" />
+                    <line x1="12" y1="16" x2="12" y2="12" />
+                    <line x1="12" y1="8" x2="12.01" y2="8" />
+                </>
+            },
+            AlertKind::Success => html! {
+                <>
+                    <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                    <polyline points="22 4 12 14.01 9 11.01" />
+                </>
+            },
+        };
+        html! {
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+                stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                { path }
+            </svg>
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct AlertProps {
+    pub kind: AlertKind,
+    pub title: AttrValue,
+    #[prop_or_default]
+    pub message: Option<AttrValue>,
+    /// Recovery actions (buttons) rendered in the alert's action row.
+    #[prop_or_default]
+    pub children: Html,
+}
+
+/// A page-level notice used to surface errors and offer a way to recover.
+#[function_component(Alert)]
+pub fn alert(props: &AlertProps) -> Html {
+    let message = props
+        .message
+        .as_ref()
+        .map(|m| html! { <p class="alert__message">{ m.clone() }</p> });
+
+    let actions = (props.children != Html::default())
+        .then(|| html! { <div class="alert__actions">{ props.children.clone() }</div> });
+
+    html! {
+        <div class={classes!("alert", props.kind.class())} role="alert">
+            <span class="alert__icon">{ props.kind.icon() }</span>
+            <div class="alert__body">
+                <span class="alert__title">{ props.title.clone() }</span>
+                { message }
+                { actions }
+            </div>
+        </div>
+    }
+}

--- a/ui/src/components/app_bar.rs
+++ b/ui/src/components/app_bar.rs
@@ -1,0 +1,313 @@
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::app::{AuthHandle, AuthStatus, Route};
+use crate::components::ProjectsContext;
+use crate::components::icons;
+use crate::search::{FIELD_PREFIXES, SearchContext, VocabularyContext};
+
+/// Up-to-two uppercase initials from a display name or email.
+fn initials(name: &str) -> String {
+    let from_words: String = name
+        .split(|c: char| c.is_whitespace() || c == '.' || c == '@' || c == '_' || c == '-')
+        .filter(|w| !w.is_empty())
+        .filter_map(|w| w.chars().next())
+        .take(2)
+        .collect();
+    let initials = if from_words.is_empty() {
+        name.chars().take(2).collect()
+    } else {
+        from_words
+    };
+    initials.to_uppercase()
+}
+
+fn input_value(event: &InputEvent) -> String {
+    event
+        .target_dyn_into::<HtmlInputElement>()
+        .map(|input| input.value())
+        .unwrap_or_default()
+}
+
+const MAX_SUGGESTIONS: usize = 8;
+
+/// One autocomplete entry. Applying it either navigates (e.g. jumping to a
+/// project) or rewrites the query text (field-prefix and value completions).
+struct Suggestion {
+    label: AttrValue,
+    desc: Option<AttrValue>,
+    /// The query string this produces when applied (used when `nav` is `None`).
+    replacement: String,
+    /// When set, applying this suggestion navigates instead of editing the query.
+    nav: Option<Route>,
+}
+
+fn is_project_field(field: &str) -> bool {
+    matches!(field.to_ascii_lowercase().as_str(), "project" | "proj" | "p")
+}
+
+/// The persistent top app bar: brand mark, the unified contextual search, and the
+/// signed-in user chip.
+#[function_component(AppBar)]
+pub fn app_bar() -> Html {
+    let auth = use_context::<AuthHandle>().expect("AuthHandle context");
+    let search = use_context::<SearchContext>();
+    let vocabulary = use_context::<VocabularyContext>();
+    let projects = use_context::<ProjectsContext>();
+    let navigator = use_navigator();
+
+    let signed_in = matches!(auth.status, AuthStatus::SignedIn(_) | AuthStatus::Disabled);
+
+    let highlight = use_state(|| None::<usize>);
+    let dismissed = use_state(|| false);
+
+    let search = match (signed_in, search) {
+        (true, Some(search)) => {
+            let query_str = search.query.to_string();
+            let active_token = query_str.rsplit(char::is_whitespace).next().unwrap_or_default();
+            let head = query_str[..query_str.len() - active_token.len()].to_string();
+
+            let mut suggestions: Vec<Suggestion> = Vec::new();
+
+            if active_token.is_empty() {
+                // Nothing typed yet — no dropdown.
+            } else if let Some((field, partial)) = active_token.split_once(':') {
+                let needle = partial.to_lowercase();
+                if is_project_field(field) {
+                    // Jump straight to a matching project.
+                    if let Some(projects) = projects.as_ref() {
+                        for project in projects.projects.iter() {
+                            if project.name.to_lowercase().contains(&needle) {
+                                suggestions.push(Suggestion {
+                                    label: AttrValue::from(project.name.clone()),
+                                    desc: Some(AttrValue::from("Go to project")),
+                                    replacement: String::new(),
+                                    nav: Some(Route::Project { id: project.id.clone() }),
+                                });
+                            }
+                        }
+                    }
+                } else if let Some(values) =
+                    vocabulary.as_ref().and_then(|v| v.vocabulary.values_for(field))
+                {
+                    for value in values {
+                        if value.to_lowercase().contains(&needle) {
+                            suggestions.push(Suggestion {
+                                label: value.clone(),
+                                desc: None,
+                                replacement: format!("{head}{field}:{value} "),
+                                nav: None,
+                            });
+                        }
+                    }
+                }
+            } else {
+                // A bare term: offer matching projects to jump to, then the
+                // `field:` prefixes (so the syntax is discoverable).
+                let needle = active_token.to_lowercase();
+                if let Some(projects) = projects.as_ref() {
+                    for project in projects.projects.iter() {
+                        if project.name.to_lowercase().contains(&needle) {
+                            suggestions.push(Suggestion {
+                                label: AttrValue::from(project.name.clone()),
+                                desc: Some(AttrValue::from("Go to project")),
+                                replacement: String::new(),
+                                nav: Some(Route::Project { id: project.id.clone() }),
+                            });
+                        }
+                    }
+                }
+                for (prefix, desc) in FIELD_PREFIXES {
+                    if prefix.starts_with(needle.as_str()) {
+                        suggestions.push(Suggestion {
+                            label: AttrValue::from(*prefix),
+                            desc: Some(AttrValue::from(*desc)),
+                            replacement: format!("{head}{prefix}"),
+                            nav: None,
+                        });
+                    }
+                }
+            }
+
+            suggestions.truncate(MAX_SUGGESTIONS);
+            let show = !suggestions.is_empty() && !*dismissed;
+
+            // Pre-compute the apply action for each suggestion (nav or text).
+            let actions: Vec<(Option<Route>, String)> =
+                suggestions.iter().map(|s| (s.nav.clone(), s.replacement.clone())).collect();
+
+            let apply = {
+                let set = search.set.clone();
+                let navigator = navigator.clone();
+                let highlight = highlight.clone();
+                move |action: &(Option<Route>, String)| {
+                    highlight.set(None);
+                    match &action.0 {
+                        Some(route) => {
+                            if let Some(nav) = &navigator {
+                                nav.push(route);
+                            }
+                            set.emit(String::new());
+                        }
+                        None => set.emit(action.1.clone()),
+                    }
+                }
+            };
+
+            let oninput = {
+                let set = search.set.clone();
+                let highlight = highlight.clone();
+                let dismissed = dismissed.clone();
+                Callback::from(move |e: InputEvent| {
+                    highlight.set(None);
+                    dismissed.set(false);
+                    set.emit(input_value(&e));
+                })
+            };
+
+            let onkeydown = {
+                let actions = actions.clone();
+                let apply = apply.clone();
+                let highlight = highlight.clone();
+                let dismissed = dismissed.clone();
+                Callback::from(move |e: KeyboardEvent| {
+                    if actions.is_empty() {
+                        return;
+                    }
+                    match e.key().as_str() {
+                        "ArrowDown" => {
+                            e.prevent_default();
+                            let next = match *highlight {
+                                Some(i) => (i + 1) % actions.len(),
+                                None => 0,
+                            };
+                            highlight.set(Some(next));
+                        }
+                        "ArrowUp" => {
+                            e.prevent_default();
+                            let next = match *highlight {
+                                Some(0) | None => actions.len() - 1,
+                                Some(i) => i - 1,
+                            };
+                            highlight.set(Some(next));
+                        }
+                        "Enter" | "Tab" => {
+                            if let Some(i) = *highlight {
+                                e.prevent_default();
+                                apply(&actions[i]);
+                            }
+                        }
+                        "Escape" => {
+                            e.prevent_default();
+                            dismissed.set(true);
+                            highlight.set(None);
+                        }
+                        _ => {}
+                    }
+                })
+            };
+
+            let dropdown = if show {
+                let items = suggestions
+                    .iter()
+                    .enumerate()
+                    .map(|(i, suggestion)| {
+                        let active = *highlight == Some(i);
+                        let onmousedown = {
+                            let apply = apply.clone();
+                            let action = actions[i].clone();
+                            Callback::from(move |e: MouseEvent| {
+                                e.prevent_default();
+                                apply(&action);
+                            })
+                        };
+                        let onmouseenter = {
+                            let highlight = highlight.clone();
+                            Callback::from(move |_: MouseEvent| highlight.set(Some(i)))
+                        };
+                        let class = classes!(
+                            "app-bar__suggestion",
+                            active.then_some("app-bar__suggestion--active")
+                        );
+                        let desc = match &suggestion.desc {
+                            Some(desc) => {
+                                html! { <span class="app-bar__suggestion-desc">{ desc.clone() }</span> }
+                            }
+                            None => html! {},
+                        };
+                        html! {
+                            <li id={format!("search-opt-{i}")} class={class} role="option"
+                                aria-selected={active.to_string()}
+                                onmousedown={onmousedown} onmouseenter={onmouseenter}>
+                                <span class="app-bar__suggestion-token">{ suggestion.label.clone() }</span>
+                                { desc }
+                            </li>
+                        }
+                    })
+                    .collect::<Html>();
+                html! { <ul id="search-suggestions" class="app-bar__suggestions" role="listbox">{ items }</ul> }
+            } else {
+                html! {}
+            };
+
+            html! {
+                <div class="app-bar__search">
+                    <span class="app-bar__search-icon">{ icons::search() }</span>
+                    <input
+                        type="search"
+                        class="app-bar__search-input"
+                        placeholder="Search projects, pages, sources…"
+                        value={search.query.clone()}
+                        oninput={oninput}
+                        onkeydown={onkeydown}
+                        role="combobox"
+                        aria-label="Search"
+                        aria-expanded={show.to_string()}
+                        aria-autocomplete="list"
+                        aria-controls="search-suggestions"
+                        aria-activedescendant={(*highlight).map(|i| format!("search-opt-{i}")).unwrap_or_default()}
+                    />
+                    { dropdown }
+                </div>
+            }
+        }
+        _ => html! { <div class="app-bar__spacer" /> },
+    };
+
+    let user = match &auth.user {
+        Some(user) => {
+            let on_signout = {
+                let signout = auth.signout.clone();
+                Callback::from(move |_: MouseEvent| signout.emit(()))
+            };
+            let email = match &user.email {
+                Some(email) => html! { <span class="user-chip__email">{ email.clone() }</span> },
+                None => html! {},
+            };
+            html! {
+                <div class="user-chip">
+                    <span class="user-chip__avatar">{ initials(&user.name) }</span>
+                    <span class="user-chip__meta">
+                        <span class="user-chip__name">{ user.name.clone() }</span>
+                        { email }
+                    </span>
+                    <button class="user-chip__signout" onclick={on_signout}>{ "Sign out" }</button>
+                </div>
+            }
+        }
+        None => html! {},
+    };
+
+    html! {
+        <header class="app-bar">
+            <Link<Route> to={Route::Overview} classes="app-bar__brand">
+                <img src="https://cdn.sierrasoftworks.com/logos/icon.svg" alt="Sierra Softworks" />
+                <span class="app-bar__brand-name">{ "Analytics" }</span>
+                <span class="app-bar__brand-by">{ "by Sierra Softworks" }</span>
+            </Link<Route>>
+            { search }
+            { user }
+        </header>
+    }
+}

--- a/ui/src/components/drawer.rs
+++ b/ui/src/components/drawer.rs
@@ -1,0 +1,86 @@
+//! A right-side slide-in drawer used for all create/edit wizards. It dims the page
+//! behind a scrim (click to dismiss), traps initial focus, and closes on Escape.
+
+use web_sys::HtmlElement;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct DrawerProps {
+    pub open: bool,
+    pub title: AttrValue,
+    pub on_close: Callback<()>,
+    /// The form/body content.
+    #[prop_or_default]
+    pub children: Html,
+    /// Footer actions (e.g. Cancel / Save), pinned to the bottom.
+    #[prop_or_default]
+    pub footer: Html,
+}
+
+#[function_component(Drawer)]
+pub fn drawer(props: &DrawerProps) -> Html {
+    let panel = use_node_ref();
+
+    // Move focus into the drawer when it opens, so Escape (handled on the panel)
+    // works immediately and keyboard users land inside the dialog.
+    {
+        let panel = panel.clone();
+        use_effect_with(props.open, move |&open| {
+            if open && let Some(el) = panel.cast::<HtmlElement>() {
+                let _ = el.focus();
+            }
+            || ()
+        });
+    }
+
+    if !props.open {
+        return html! {};
+    }
+
+    let close = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| on_close.emit(()))
+    };
+    let on_keydown = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |e: KeyboardEvent| {
+            if e.key() == "Escape" {
+                on_close.emit(());
+            }
+        })
+    };
+    // Swallow clicks inside the panel so they don't reach the scrim.
+    let stop = Callback::from(|e: MouseEvent| e.stop_propagation());
+
+    let footer = (props.footer != Html::default())
+        .then(|| html! { <footer class="drawer__footer">{ props.footer.clone() }</footer> });
+
+    html! {
+        <div class="drawer-root">
+            <div class="drawer__scrim" onclick={close.clone()} />
+            <aside
+                ref={panel}
+                class="drawer"
+                role="dialog"
+                aria-modal="true"
+                aria-label={props.title.clone()}
+                tabindex="-1"
+                onkeydown={on_keydown}
+                onclick={stop}
+            >
+                <header class="drawer__head">
+                    <h2 class="drawer__title">{ props.title.clone() }</h2>
+                    <button class="drawer__close" aria-label="Close" onclick={close}>
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                    </button>
+                </header>
+                <div class="drawer__body">{ props.children.clone() }</div>
+                { footer }
+            </aside>
+        </div>
+    }
+}

--- a/ui/src/components/dropdown.rs
+++ b/ui/src/components/dropdown.rs
@@ -1,0 +1,137 @@
+//! A cohesively-themed dropdown (custom `<select>` replacement) so menus match the
+//! dark theme rather than rendering the OS-native control. The menu is positioned
+//! `fixed` against the trigger's measured rect so it is never clipped by a scrolling
+//! ancestor (e.g. a drawer body). It closes on selection, Escape, or a click outside.
+
+use web_sys::HtmlElement;
+use yew::prelude::*;
+
+#[derive(Clone, PartialEq)]
+pub struct DropdownItem {
+    pub value: AttrValue,
+    pub label: AttrValue,
+}
+
+impl DropdownItem {
+    pub fn new(value: impl Into<AttrValue>, label: impl Into<AttrValue>) -> Self {
+        Self { value: value.into(), label: label.into() }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct DropdownProps {
+    pub items: Vec<DropdownItem>,
+    /// The currently-selected value (matched against `items[].value`).
+    #[prop_or_default]
+    pub value: AttrValue,
+    pub on_select: Callback<String>,
+    /// Shown on the trigger when nothing matches `value`.
+    #[prop_or_default]
+    pub placeholder: AttrValue,
+    /// Stretch to fill the container (for use inside forms/drawers).
+    #[prop_or(false)]
+    pub block: bool,
+    #[prop_or(false)]
+    pub disabled: bool,
+}
+
+#[function_component(Dropdown)]
+pub fn dropdown(props: &DropdownProps) -> Html {
+    let open = use_state(|| false);
+    // `(top, left, width)` of the menu, measured from the trigger when opening.
+    let anchor = use_state(|| (0.0f64, 0.0f64, 0.0f64));
+    let trigger = use_node_ref();
+
+    let current = props
+        .items
+        .iter()
+        .find(|i| i.value == props.value)
+        .map(|i| i.label.clone());
+
+    let toggle = {
+        let (open, anchor, trigger) = (open.clone(), anchor.clone(), trigger.clone());
+        Callback::from(move |_: MouseEvent| {
+            if *open {
+                open.set(false);
+            } else {
+                if let Some(el) = trigger.cast::<HtmlElement>() {
+                    let r = el.get_bounding_client_rect();
+                    anchor.set((r.bottom() + 4.0, r.left(), r.width()));
+                }
+                open.set(true);
+            }
+        })
+    };
+    let close = {
+        let open = open.clone();
+        Callback::from(move |_: MouseEvent| open.set(false))
+    };
+    // Escape collapses the menu (and stops the event so an enclosing drawer's own
+    // Escape-to-close doesn't also fire); when closed, the event bubbles normally.
+    let on_keydown = {
+        let open = open.clone();
+        Callback::from(move |e: KeyboardEvent| {
+            if *open && e.key() == "Escape" {
+                e.stop_propagation();
+                open.set(false);
+            }
+        })
+    };
+
+    let menu = open.then(|| {
+        let (top, left, width) = *anchor;
+        let style = format!("top:{top}px; left:{left}px; min-width:{width}px;");
+        let options = props.items.iter().map(|item| {
+            let selected = item.value == props.value;
+            let onclick = {
+                let (on_select, open, value) = (props.on_select.clone(), open.clone(), item.value.to_string());
+                Callback::from(move |_: MouseEvent| {
+                    on_select.emit(value.clone());
+                    open.set(false);
+                })
+            };
+            let class = classes!("dropdown__option", selected.then_some("dropdown__option--selected"));
+            html! {
+                <li class={class} role="option" aria-selected={selected.to_string()} onclick={onclick}>
+                    <span>{ item.label.clone() }</span>
+                    if selected {
+                        <svg class="dropdown__check" viewBox="0 0 24 24" width="14" height="14" fill="none"
+                            stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                    }
+                </li>
+            }
+        }).collect::<Html>();
+        html! {
+            <>
+                <div class="dropdown__backdrop" onclick={close} />
+                <ul class="dropdown__menu" role="listbox" style={style}>{ options }</ul>
+            </>
+        }
+    });
+
+    let label = current.unwrap_or_else(|| props.placeholder.clone());
+    let class = classes!("dropdown", props.block.then_some("dropdown--block"));
+
+    html! {
+        <div class={class} onkeydown={on_keydown}>
+            <button
+                ref={trigger}
+                type="button"
+                class="dropdown__trigger"
+                onclick={toggle}
+                disabled={props.disabled}
+                aria-haspopup="listbox"
+                aria-expanded={open.to_string()}
+            >
+                <span class="dropdown__label">{ label }</span>
+                <svg class="dropdown__caret" viewBox="0 0 24 24" width="15" height="15" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="6 9 12 15 18 9" />
+                </svg>
+            </button>
+            { menu }
+        </div>
+    }
+}

--- a/ui/src/components/error.rs
+++ b/ui/src/components/error.rs
@@ -6,6 +6,7 @@ use yew::prelude::*;
 
 use crate::api::ApiError;
 use crate::app::AuthHandle;
+use crate::components::{Alert, AlertKind};
 
 #[derive(Properties, PartialEq)]
 pub struct ApiErrorAlertProps {
@@ -20,18 +21,22 @@ pub fn api_error_alert(props: &ApiErrorAlertProps) -> Html {
     {
         let relogin = auth.as_ref().map(|a| a.relogin.clone());
         use_effect_with(unauthorized, move |&unauthorized| {
-            if unauthorized {
-                if let Some(relogin) = relogin {
-                    relogin.emit(());
-                }
+            if unauthorized && let Some(relogin) = relogin {
+                relogin.emit(());
             }
             || ()
         });
     }
 
     if unauthorized {
-        html! { <p class="muted">{ "Your session expired. Returning to sign in…" }</p> }
+        html! {
+            <Alert kind={AlertKind::Info} title="Your session expired"
+                message="Returning you to sign in…" />
+        }
     } else {
-        html! { <div class="alert alert--error">{ props.error.to_string() }</div> }
+        html! {
+            <Alert kind={AlertKind::Error} title="Something went wrong"
+                message={AttrValue::from(props.error.to_string())} />
+        }
     }
 }

--- a/ui/src/components/icons.rs
+++ b/ui/src/components/icons.rs
@@ -1,0 +1,71 @@
+//! Small inline SVG glyphs shared across the chrome. Each returns a stroked,
+//! `currentColor` icon so it inherits the surrounding text colour.
+
+use yew::prelude::*;
+
+fn icon(children: Html) -> Html {
+    html! {
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"
+            stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            { children }
+        </svg>
+    }
+}
+
+pub fn overview() -> Html {
+    icon(html! {
+        <>
+            <rect x="3" y="3" width="7" height="9" rx="1" />
+            <rect x="14" y="3" width="7" height="5" rx="1" />
+            <rect x="14" y="12" width="7" height="9" rx="1" />
+            <rect x="3" y="16" width="7" height="5" rx="1" />
+        </>
+    })
+}
+
+pub fn exceptions() -> Html {
+    icon(html! {
+        <>
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+        </>
+    })
+}
+
+pub fn pixels() -> Html {
+    icon(html! {
+        <>
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <path d="m21 15-5-5L5 21" />
+        </>
+    })
+}
+
+pub fn settings() -> Html {
+    icon(html! {
+        <>
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </>
+    })
+}
+
+pub fn search() -> Html {
+    icon(html! {
+        <>
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </>
+    })
+}
+
+pub fn copy() -> Html {
+    icon(html! {
+        <>
+            <rect x="9" y="9" width="13" height="13" rx="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </>
+    })
+}

--- a/ui/src/components/layout.rs
+++ b/ui/src/components/layout.rs
@@ -1,44 +1,25 @@
-use yew::prelude::*;
-use yew_router::prelude::*;
+//! The minimal public chrome (brand header) wrapping the signed-out screens:
+//! the sign-in page and the 404. The signed-in app uses [`AppShell`] instead.
+//!
+//! [`AppShell`]: crate::components::AppShell
 
-use crate::app::{AuthHandle, Route};
+use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
-pub struct LayoutProps {
+pub struct PublicLayoutProps {
     #[prop_or_default]
     pub children: Html,
 }
 
-#[function_component(Layout)]
-pub fn layout(props: &LayoutProps) -> Html {
-    let auth = use_context::<AuthHandle>();
-    let user = auth.as_ref().and_then(|a| a.user.clone());
-    let signout = auth.as_ref().map(|a| a.signout.clone());
-
+#[function_component(PublicLayout)]
+pub fn public_layout(props: &PublicLayoutProps) -> Html {
     html! {
-        <>
-            <header class="topbar">
-                <div class="topbar__brand">
-                    <Link<Route> to={Route::Overview} classes="brand">{ "Analytics" }</Link<Route>>
-                    <span class="brand__by">{ "by Sierra Softworks" }</span>
-                </div>
-                <nav class="topbar__nav">
-                    <Link<Route> to={Route::Overview}>{ "Overview" }</Link<Route>>
-                    <Link<Route> to={Route::Sources}>{ "Sources" }</Link<Route>>
-                </nav>
-                <div class="topbar__user">
-                    if let Some(user) = user {
-                        <span class="muted">{ user.name }</span>
-                        if let Some(signout) = signout {
-                            <button
-                                class="btn btn--ghost"
-                                onclick={Callback::from(move |_| signout.emit(()))}
-                            >{ "Sign out" }</button>
-                        }
-                    }
-                </div>
-            </header>
-            <main class="content">{ props.children.clone() }</main>
-        </>
+        <div class="public-shell">
+            <div class="public-header">
+                <img src="https://cdn.sierrasoftworks.com/logos/icon.svg" alt="Sierra Softworks" />
+                <span>{ "Analytics" }</span>
+            </div>
+            { props.children.clone() }
+        </div>
     }
 }

--- a/ui/src/components/mod.rs
+++ b/ui/src/components/mod.rs
@@ -1,7 +1,24 @@
+mod alert;
+mod app_bar;
+mod drawer;
+mod dropdown;
 mod error;
+pub mod icons;
 mod layout;
+mod page_header;
+mod range_picker;
+mod shell;
+mod sidebar;
 mod widgets;
 
+pub use alert::{Alert, AlertKind};
+pub use app_bar::AppBar;
+pub use drawer::Drawer;
+pub use dropdown::{Dropdown, DropdownItem};
 pub use error::ApiErrorAlert;
-pub use layout::Layout;
+pub use layout::PublicLayout;
+pub use page_header::{Crumb, PageHeader};
+pub use range_picker::{Range, RangePicker};
+pub use shell::{AppShell, ProjectsContext};
+pub use sidebar::Sidebar;
 pub use widgets::{Breakdown, MetricCards, TimeSeriesChart};

--- a/ui/src/components/page_header.rs
+++ b/ui/src/components/page_header.rs
@@ -1,0 +1,78 @@
+//! The page header shown at the top of each routed page: an optional breadcrumb
+//! trail, the page title and subtitle, and a slot for page-level actions.
+
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::app::Route;
+
+/// One breadcrumb entry. A `to` of `None` renders the (non-link) current page.
+#[derive(Clone, PartialEq)]
+pub struct Crumb {
+    pub label: AttrValue,
+    pub to: Option<Route>,
+}
+
+impl Crumb {
+    pub fn link(label: impl Into<AttrValue>, to: Route) -> Self {
+        Self { label: label.into(), to: Some(to) }
+    }
+    pub fn current(label: impl Into<AttrValue>) -> Self {
+        Self { label: label.into(), to: None }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct PageHeaderProps {
+    #[prop_or_default]
+    pub crumbs: Vec<Crumb>,
+    pub title: AttrValue,
+    #[prop_or_default]
+    pub subtitle: Option<AttrValue>,
+    /// Page-level actions aligned to the end of the title row.
+    #[prop_or_default]
+    pub children: Html,
+}
+
+#[function_component(PageHeader)]
+pub fn page_header(props: &PageHeaderProps) -> Html {
+    let breadcrumb = if props.crumbs.is_empty() {
+        html! {}
+    } else {
+        let last = props.crumbs.len() - 1;
+        let items = props.crumbs.iter().enumerate().map(|(i, crumb)| {
+            let sep = (i < last).then(|| html! { <span class="breadcrumb__sep">{ "/" }</span> });
+            let item = match &crumb.to {
+                Some(route) => html! {
+                    <Link<Route> to={route.clone()} classes="breadcrumb__item">{ crumb.label.clone() }</Link<Route>>
+                },
+                None => html! {
+                    <span class="breadcrumb__item breadcrumb__item--current">{ crumb.label.clone() }</span>
+                },
+            };
+            html! { <>{ item }{ sep }</> }
+        }).collect::<Html>();
+        html! { <nav class="breadcrumb">{ items }</nav> }
+    };
+
+    let subtitle = props
+        .subtitle
+        .as_ref()
+        .map(|s| html! { <p class="page-header__subtitle">{ s.clone() }</p> });
+
+    let actions = (props.children != Html::default())
+        .then(|| html! { <div class="page-header__actions">{ props.children.clone() }</div> });
+
+    html! {
+        <>
+            { breadcrumb }
+            <div class="page-header">
+                <div class="page-header__text">
+                    <h1 class="page-header__title">{ props.title.clone() }</h1>
+                    { subtitle }
+                </div>
+                { actions }
+            </div>
+        </>
+    }
+}

--- a/ui/src/components/range_picker.rs
+++ b/ui/src/components/range_picker.rs
@@ -1,0 +1,60 @@
+//! The lookback selector shown in page headers. It resolves a preset into the
+//! `from`/`to`/`interval` query the stats endpoints expect.
+
+use yew::prelude::*;
+
+use crate::components::{Dropdown, DropdownItem};
+
+/// A lookback window: a number of days back, paired with a sensible bucket size.
+#[derive(Clone, Copy, PartialEq)]
+pub struct Range {
+    pub days: i64,
+    pub interval: &'static str,
+}
+
+/// `(days, interval, label)` presets, in display order. Buckets coarsen with the
+/// window: 24h hourly, 7d in 6-hour windows, 30d/90d daily, a year in weeks.
+const PRESETS: &[(i64, &str, &str)] = &[
+    (1, "hour", "Last 24 hours"),
+    (7, "6h", "Last 7 days"),
+    (30, "day", "Last 30 days"),
+    (90, "day", "Last 90 days"),
+    (365, "week", "Last 12 months"),
+];
+
+impl Range {
+    /// The default lookback (7 days, daily buckets).
+    pub fn week() -> Range {
+        Range { days: 7, interval: "day" }
+    }
+
+    /// The `from`/`to`/`interval` query string for this window, anchored to now.
+    pub fn query(&self) -> String {
+        let now = js_sys::Date::now() as i64;
+        let from = now - self.days * 86_400_000;
+        format!("from={from}&to={now}&interval={}", self.interval)
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct RangePickerProps {
+    pub value: Range,
+    pub on_change: Callback<Range>,
+}
+
+#[function_component(RangePicker)]
+pub fn range_picker(props: &RangePickerProps) -> Html {
+    let items: Vec<DropdownItem> =
+        PRESETS.iter().map(|(d, _, label)| DropdownItem::new(d.to_string(), *label)).collect();
+
+    let on_select = {
+        let on_change = props.on_change.clone();
+        Callback::from(move |value: String| {
+            if let Some((days, interval, _)) = PRESETS.iter().find(|(d, _, _)| d.to_string() == value) {
+                on_change.emit(Range { days: *days, interval });
+            }
+        })
+    };
+
+    html! { <Dropdown items={items} value={props.value.days.to_string()} {on_select} /> }
+}

--- a/ui/src/components/shell.rs
+++ b/ui/src/components/shell.rs
@@ -1,0 +1,285 @@
+//! The signed-in application shell: the top app bar (brand · search · user), the
+//! left navigation sidebar, and the routed page. It owns the project list (shared
+//! with the sidebar and the `project:` search completion), the shared search query
+//! and completion vocabulary, and the create-project drawer (openable anywhere via
+//! the `ProjectsContext::open_new` callback).
+
+use std::rc::Rc;
+
+use analytics_api::{Project, ProjectInput, Source, SourceInput, source_label};
+use chrono::{Datelike, Utc};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::api;
+use crate::app::Route;
+use crate::components::{AppBar, Drawer, Sidebar};
+use crate::search::{SearchContext, SearchFilter, SearchVocabulary, VocabularyContext};
+
+/// The project list, shared by the sidebar and the `project:` search completion,
+/// plus callbacks to refresh it and to open the create-project drawer.
+#[derive(Clone, PartialEq)]
+pub struct ProjectsContext {
+    pub projects: Rc<Vec<Project>>,
+    pub reload: Callback<()>,
+    pub open_new: Callback<()>,
+}
+
+#[derive(Properties, PartialEq)]
+pub struct AppShellProps {
+    #[prop_or_default]
+    pub children: Html,
+}
+
+/// A monotonic refresh counter driven through a reducer so that a *stable*
+/// (memoized) reload callback still increments correctly — a plain `use_state`
+/// handle captured in a `use_memo` would snapshot its value and only fire once.
+#[derive(PartialEq)]
+struct Tick(u32);
+impl Reducible for Tick {
+    type Action = ();
+    fn reduce(self: Rc<Self>, _: ()) -> Rc<Self> {
+        Rc::new(Tick(self.0.wrapping_add(1)))
+    }
+}
+
+#[function_component(AppShell)]
+pub fn app_shell(props: &AppShellProps) -> Html {
+    let navigator = use_navigator();
+
+    // The project list, refreshed whenever `tick` changes.
+    let projects = use_state(|| Rc::new(Vec::<Project>::new()));
+    let tick = use_reducer(|| Tick(0));
+    {
+        let projects = projects.clone();
+        use_effect_with(tick.0, move |_| {
+            spawn_local(async move {
+                if let Ok(mut list) = api::list_projects().await {
+                    list.sort_by_key(|p| p.name.to_lowercase());
+                    projects.set(Rc::new(list));
+                }
+            });
+            || ()
+        });
+    }
+    let reload = {
+        let dispatcher = tick.dispatcher();
+        use_memo((), move |_| Callback::from(move |_| dispatcher.dispatch(())))
+    };
+
+    // Create-project drawer state.
+    let drawer_open = use_state(|| false);
+    let new_name = use_state(String::new);
+    let new_error = use_state(|| None::<String>);
+    let submitting = use_state(|| false);
+    let avail_sources = use_state(Vec::<Source>::new);
+    let selected = use_state(Vec::<String>::new);
+
+    let open_new = {
+        let (drawer_open, new_name, new_error, selected, avail_sources) = (
+            drawer_open.clone(), new_name.clone(), new_error.clone(),
+            selected.clone(), avail_sources.clone(),
+        );
+        use_memo((), move |_| {
+            let (drawer_open, new_name, new_error, selected, avail_sources) = (
+                drawer_open.clone(), new_name.clone(), new_error.clone(),
+                selected.clone(), avail_sources.clone(),
+            );
+            Callback::from(move |_| {
+                new_name.set(String::new());
+                new_error.set(None);
+                selected.set(Vec::new());
+                avail_sources.set(Vec::new()); // clear stale list so it doesn't flash
+                drawer_open.set(true);
+                let avail_sources = avail_sources.clone();
+                spawn_local(async move {
+                    if let Ok(list) = api::list_sources().await {
+                        avail_sources.set(list);
+                    }
+                });
+            })
+        })
+    };
+
+    let projects_ctx = ProjectsContext {
+        projects: (*projects).clone(),
+        reload: (*reload).clone(),
+        open_new: (*open_new).clone(),
+    };
+
+    let close_drawer = {
+        let drawer_open = drawer_open.clone();
+        Callback::from(move |_| drawer_open.set(false))
+    };
+    let on_name = {
+        let new_name = new_name.clone();
+        Callback::from(move |e: InputEvent| {
+            new_name.set(e.target_unchecked_into::<HtmlInputElement>().value());
+        })
+    };
+    let toggle_source = {
+        let selected = selected.clone();
+        Callback::from(move |uri: String| {
+            let mut s = (*selected).clone();
+            if let Some(pos) = s.iter().position(|u| u == &uri) {
+                s.remove(pos);
+            } else {
+                s.push(uri);
+            }
+            selected.set(s);
+        })
+    };
+    let on_create = {
+        let (new_name, new_error, submitting, drawer_open, selected) = (
+            new_name.clone(), new_error.clone(), submitting.clone(),
+            drawer_open.clone(), selected.clone(),
+        );
+        let (dispatcher, navigator) = (tick.dispatcher(), navigator.clone());
+        Callback::from(move |_| {
+            let chosen = (*selected).clone();
+            // Default the name to the first added source when left blank.
+            let mut name = (*new_name).trim().to_string();
+            if name.is_empty() && let Some(first) = chosen.first() {
+                name = source_label(first).to_string();
+            }
+            if name.is_empty() {
+                new_error.set(Some("Enter a project name, or add a source to name it after.".to_string()));
+                return;
+            }
+            let (new_error, submitting, drawer_open) =
+                (new_error.clone(), submitting.clone(), drawer_open.clone());
+            let (dispatcher, navigator) = (dispatcher.clone(), navigator.clone());
+            submitting.set(true);
+            spawn_local(async move {
+                match api::create_project(&ProjectInput { name, slug: None }).await {
+                    Ok(project) => {
+                        for uri in &chosen {
+                            let input =
+                                SourceInput { project_id: Some(project.id.clone()), ..Default::default() };
+                            let _ = api::update_source(uri, &input).await;
+                        }
+                        dispatcher.dispatch(());
+                        drawer_open.set(false);
+                        if let Some(nav) = &navigator {
+                            nav.push(&Route::Project { id: project.id });
+                        }
+                    }
+                    Err(err) => new_error.set(Some(err.to_string())),
+                }
+                submitting.set(false);
+            });
+        })
+    };
+
+    // The shared search query lives here, above both the app bar (which owns the
+    // input) and the routed page (which consumes the parsed filter), so a page's
+    // re-render never disturbs input focus.
+    let query = use_state(String::new);
+    let set_query = {
+        let query = query.clone();
+        use_memo((), move |_| Callback::from(move |value: String| query.set(value)))
+    };
+    let search = SearchContext {
+        query: AttrValue::from((*query).clone()),
+        filter: Rc::new(SearchFilter::parse(&query)),
+        set: (*set_query).clone(),
+    };
+
+    // The page-published completion vocabulary (pages/sources/statuses).
+    let vocabulary = use_state(|| Rc::new(SearchVocabulary::default()));
+    let set_vocabulary = {
+        let vocabulary = vocabulary.clone();
+        use_memo((), move |_| {
+            Callback::from(move |value: SearchVocabulary| vocabulary.set(Rc::new(value)))
+        })
+    };
+    let vocabulary_ctx = VocabularyContext {
+        vocabulary: (*vocabulary).clone(),
+        set: (*set_vocabulary).clone(),
+    };
+
+    let error = (*new_error)
+        .as_ref()
+        .map(|e| html! { <p class="drawer__hint" style="color: var(--danger);">{ e.clone() }</p> });
+
+    html! {
+        <ContextProvider<ProjectsContext> context={projects_ctx}>
+            <ContextProvider<SearchContext> context={search}>
+                <ContextProvider<VocabularyContext> context={vocabulary_ctx}>
+                    <div class="app-shell">
+                        <AppBar />
+                        <div class="app-body">
+                            <Sidebar />
+                            <main class="app-main">
+                                <div class="app-content">{ props.children.clone() }</div>
+                                <footer class="app-footer">
+                                    { format!("© Sierra Softworks {}", Utc::now().year()) }
+                                </footer>
+                            </main>
+                        </div>
+                    </div>
+                    <Drawer open={*drawer_open} title="New project" on_close={close_drawer.clone()}
+                        footer={drawer_footer(&close_drawer, &on_create, *submitting)}>
+                        <div class="field">
+                            <label class="field__label">{ "Project name" }</label>
+                            <input class="input" placeholder="Defaults to the first source added"
+                                value={(*new_name).clone()} oninput={on_name} />
+                        </div>
+                        <div class="field">
+                            <label class="field__label">{ "Add sources" }</label>
+                            if avail_sources.is_empty() {
+                                <p class="drawer__hint">{ "No reporting sources yet — they appear here once a site starts reporting." }</p>
+                            } else {
+                                { for (*avail_sources).iter().map(|s| {
+                                    let uri = s.uri.clone();
+                                    let chosen = (*selected).contains(&uri);
+                                    // Surface current ownership: adding a source already in
+                                    // another project will move it here.
+                                    let owner = s.project_id.as_ref()
+                                        .and_then(|pid| projects.iter().find(|p| &p.id == pid))
+                                        .map(|p| p.name.clone());
+                                    let onclick = {
+                                        let (toggle, uri) = (toggle_source.clone(), uri.clone());
+                                        Callback::from(move |_| toggle.emit(uri.clone()))
+                                    };
+                                    let (label, class) = if chosen {
+                                        ("Remove", "btn btn--small btn--ghost")
+                                    } else {
+                                        ("Add", "btn btn--small")
+                                    };
+                                    html! {
+                                        <div class="toggle-row">
+                                            <span class="toggle-row__label" title={s.uri.clone()}>{ source_label(&s.uri) }</span>
+                                            if let Some(owner) = owner {
+                                                <span class="badge badge--muted">{ format!("in {owner}") }</span>
+                                            }
+                                            <button class={class} {onclick}>{ label }</button>
+                                        </div>
+                                    }
+                                }) }
+                            }
+                        </div>
+                        { error }
+                    </Drawer>
+                </ContextProvider<VocabularyContext>>
+            </ContextProvider<SearchContext>>
+        </ContextProvider<ProjectsContext>>
+    }
+}
+
+fn drawer_footer(close: &Callback<()>, create: &Callback<MouseEvent>, busy: bool) -> Html {
+    let on_cancel = {
+        let close = close.clone();
+        Callback::from(move |_: MouseEvent| close.emit(()))
+    };
+    html! {
+        <>
+            <button class="btn btn--ghost" onclick={on_cancel}>{ "Cancel" }</button>
+            <button class="btn btn--primary" onclick={create.clone()} disabled={busy}>
+                { if busy { "Creating…" } else { "Create project" } }
+            </button>
+        </>
+    }
+}

--- a/ui/src/components/sidebar.rs
+++ b/ui/src/components/sidebar.rs
@@ -1,0 +1,75 @@
+//! The left navigation sidebar: Overview, Exceptions, the project list (shown only
+//! when projects exist), Tracking pixels, and Settings. The active route is
+//! highlighted; the project list comes from the shared [`ProjectsContext`]. Project
+//! creation lives in the Overview header, not here.
+
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::app::Route;
+use crate::components::ProjectsContext;
+use crate::components::icons;
+
+#[function_component(Sidebar)]
+pub fn sidebar() -> Html {
+    let projects_ctx = use_context::<ProjectsContext>();
+    let route = use_route::<Route>();
+
+    let projects = projects_ctx
+        .as_ref()
+        .map(|c| c.projects.clone())
+        .unwrap_or_default();
+
+    let is_overview = matches!(route, Some(Route::Overview));
+    let is_exceptions = matches!(route, Some(Route::Exceptions));
+    let is_pixels = matches!(route, Some(Route::Pixels));
+    let is_settings = matches!(route, Some(Route::Settings));
+    let active_project = match &route {
+        Some(Route::Project { id }) => Some(id.clone()),
+        Some(Route::Exception { project, .. }) => Some(project.clone()),
+        _ => None,
+    };
+
+    let menu_item = |active: bool, route: Route, icon: Html, label: &str| {
+        let class = classes!("menu__item", active.then_some("menu__item--active"));
+        html! {
+            <li>
+                <Link<Route> to={route} classes={class}>
+                    <span class="menu__icon">{ icon }</span>
+                    <span class="menu__label">{ label.to_string() }</span>
+                </Link<Route>>
+            </li>
+        }
+    };
+
+    let project_items = projects.iter().map(|p| {
+        let active = active_project.as_deref() == Some(p.id.as_str());
+        let class = classes!("menu__subitem", active.then_some("menu__subitem--active"));
+        html! {
+            <li>
+                <Link<Route> to={Route::Project { id: p.id.clone() }} classes={class}>
+                    <span class="menu__dot" />
+                    <span class="menu__label">{ &p.name }</span>
+                </Link<Route>>
+            </li>
+        }
+    }).collect::<Html>();
+
+    html! {
+        <nav class="app-sidebar">
+            <ul class="menu">
+                { menu_item(is_overview, Route::Overview, icons::overview(), "Overview") }
+                { menu_item(is_exceptions, Route::Exceptions, icons::exceptions(), "Exceptions") }
+
+                if !projects.is_empty() {
+                    <li class="menu__section">{ "Projects" }</li>
+                    <ul class="menu__sub">{ project_items }</ul>
+                }
+
+                <li class="menu__section">{ "Manage" }</li>
+                { menu_item(is_pixels, Route::Pixels, icons::pixels(), "Tracking pixels") }
+                { menu_item(is_settings, Route::Settings, icons::settings(), "Settings") }
+            </ul>
+        </nav>
+    }
+}

--- a/ui/src/components/widgets.rs
+++ b/ui/src/components/widgets.rs
@@ -6,6 +6,7 @@ pub struct MetricCardsProps {
     pub summary: MetricSummary,
 }
 
+/// The four headline metrics, rendered as Element-Plus-style statistic cards.
 #[function_component(MetricCards)]
 pub fn metric_cards(props: &MetricCardsProps) -> Html {
     let s = &props.summary;
@@ -19,22 +20,35 @@ pub fn metric_cards(props: &MetricCardsProps) -> Html {
         .unwrap_or_else(|| "—".to_string());
 
     html! {
-        <div class="cards">
-            { card(&s.visitors.to_string(), "Visitors") }
-            { card(&s.pageviews.to_string(), "Page views") }
-            { card(&bounce, "Bounce rate") }
-            { card(&duration, "Median time") }
+        <div class="stats">
+            { stat("Visitors", &group_thousands(s.visitors)) }
+            { stat("Page views", &group_thousands(s.pageviews)) }
+            { stat("Bounce rate", &bounce) }
+            { stat("Median time", &duration) }
         </div>
     }
 }
 
-fn card(value: &str, label: &str) -> Html {
+fn stat(label: &str, value: &str) -> Html {
     html! {
-        <div class="card">
-            <div class="card__value">{ value }</div>
-            <div class="card__label">{ label }</div>
+        <div class="stat">
+            <span class="stat__label">{ label }</span>
+            <span class="stat__value">{ value }</span>
         </div>
     }
+}
+
+/// Group an integer with thin thousands separators, e.g. `12,345`.
+fn group_thousands(n: i64) -> String {
+    let s = n.abs().to_string();
+    let mut out = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    if n < 0 { format!("-{out}") } else { out }
 }
 
 fn format_duration(ms: i64) -> String {
@@ -59,18 +73,20 @@ pub fn time_series_chart(props: &TimeSeriesChartProps) -> Html {
 
     let max = points.iter().map(|p| p.pageviews).max().unwrap_or(1).max(1) as f64;
     let slot = 100.0 / points.len() as f64;
+    // Cap the bar width and centre it in its slot so a single (or few) data point(s)
+    // render as discrete bars rather than one block stretched across the whole chart.
+    const MAX_BAR: f64 = 7.0;
+    let bar_w = (slot * 0.8).min(MAX_BAR);
 
     let bars = points.iter().enumerate().map(|(i, p)| {
         let height = (p.pageviews as f64 / max) * 100.0;
-        let x = i as f64 * slot;
+        let x = i as f64 * slot + (slot - bar_w) / 2.0;
         html! {
-            <rect
-                class="bar"
+            <rect class="bar" rx="0.4"
                 x={format!("{:.3}", x)}
                 y={format!("{:.3}", 100.0 - height)}
-                width={format!("{:.3}", slot * 0.8)}
-                height={format!("{:.3}", height)}
-            >
+                width={format!("{:.3}", bar_w)}
+                height={format!("{:.3}", height)}>
                 <title>{ format!("{} views · {} visitors", p.pageviews, p.visitors) }</title>
             </rect>
         }
@@ -97,7 +113,7 @@ pub fn breakdown(props: &BreakdownProps) -> Html {
             if props.rows.is_empty() {
                 <p class="muted">{ "No data." }</p>
             } else {
-                <table>
+                <table aria-label={props.title.clone()}>
                     { for props.rows.iter().map(|row| html! {
                         <tr>
                             <td class="breakdown__key" title={row.key.clone()}>{ &row.key }</td>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3,6 +3,7 @@ mod app;
 mod auth;
 mod components;
 mod pages;
+mod search;
 
 fn main() {
     console_error_panic_hook::set_once();

--- a/ui/src/pages/exception_detail.rs
+++ b/ui/src/pages/exception_detail.rs
@@ -1,11 +1,10 @@
 use analytics_api::{ExceptionGroupDetail, ExceptionStatus, TriageInput};
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
-use yew_router::prelude::*;
 
 use crate::api::{self, ApiError};
 use crate::app::Route;
-use crate::components::ApiErrorAlert;
+use crate::components::{ApiErrorAlert, Crumb, PageHeader};
 use crate::pages::project::{status_class, status_label};
 
 #[derive(Properties, PartialEq)]
@@ -23,7 +22,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     {
         let detail = detail.clone();
         let (project, group) = (project.clone(), group.clone());
-        // `project` is part of the deps: two projects can share a fingerprint, so
+        // `project` is a dependency: two projects can share a fingerprint, so
         // navigating between same-group exceptions across projects must refetch.
         use_effect_with((project.clone(), group.clone(), *reload), move |_| {
             spawn_local(async move {
@@ -36,11 +35,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     let set_status = {
         let (project, group, reload) = (project.clone(), group.clone(), reload.clone());
         move |status: ExceptionStatus| {
-            let input = TriageInput {
-                project_id: project.clone(),
-                status,
-                note: None,
-            };
+            let input = TriageInput { project_id: project.clone(), status, note: None };
             let (group, reload) = (group.clone(), reload.clone());
             Callback::from(move |_| {
                 let (group, input, reload) = (group.clone(), input.clone(), reload.clone());
@@ -53,11 +48,19 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
         }
     };
 
+    let title = match &*detail {
+        Some(Ok(d)) => d.group.exc_type.clone(),
+        _ => "Exception".to_string(),
+    };
+    let crumbs = vec![
+        Crumb::link("Overview", Route::Overview),
+        Crumb::link("Project", Route::Project { id: project.clone() }),
+        Crumb::current(title.clone()),
+    ];
+
     html! {
         <div class="page">
-            <p class="crumb">
-                <Link<Route> to={Route::Project { id: project.clone() }}>{ "← Back to project" }</Link<Route>>
-            </p>
+            <PageHeader crumbs={crumbs} title={title} />
             {
                 match &*detail {
                     None => html! { <p class="muted">{ "Loading…" }</p> },
@@ -65,17 +68,16 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
                     Some(Ok(detail)) => html! {
                         <>
                             <div class="exc-header">
-                                <h1>{ &detail.group.exc_type }</h1>
                                 <span class={status_class(detail.group.status)}>{ status_label(detail.group.status) }</span>
+                                <span class="muted">{ format!("{} occurrences", detail.group.count) }</span>
                             </div>
                             <p class="exc-message">{ &detail.group.sample_message }</p>
-                            <p class="muted">{ format!("{} occurrences", detail.group.count) }</p>
                             <div class="form-row">
                                 <button class="btn" onclick={set_status(ExceptionStatus::Resolved)}>{ "Mark resolved" }</button>
                                 <button class="btn" onclick={set_status(ExceptionStatus::Ignored)}>{ "Ignore" }</button>
                                 <button class="btn btn--ghost" onclick={set_status(ExceptionStatus::Unresolved)}>{ "Reopen" }</button>
                             </div>
-                            <h2>{ "Recent occurrences" }</h2>
+                            <h2 class="section__title">{ "Recent occurrences" }</h2>
                             { for detail.occurrences.iter().map(occurrence) }
                         </>
                     },
@@ -93,7 +95,7 @@ fn occurrence(o: &analytics_api::ExceptionOccurrence) -> Html {
     };
     html! {
         <div class="occurrence">
-            <div class="occurrence__meta muted">{ format!("{} · {}", ua, if o.handled { "handled" } else { "unhandled" }) }</div>
+            <div class="occurrence__meta">{ format!("{} · {}", ua, if o.handled { "handled" } else { "unhandled" }) }</div>
             <div>{ &o.message }</div>
             if let Some(stack) = &o.stack {
                 <pre class="stack">{ stack }</pre>

--- a/ui/src/pages/exceptions.rs
+++ b/ui/src/pages/exceptions.rs
@@ -1,0 +1,133 @@
+//! The global Exceptions inbox: recent crashes/failures across every project (and
+//! unassigned sources), for triage and investigation.
+
+use analytics_api::GlobalException;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::api::{self, ApiError};
+use crate::app::Route;
+use crate::components::{ApiErrorAlert, PageHeader, Range, RangePicker};
+use crate::pages::project::{status_class, status_label};
+use crate::search::{MatchContext, SearchContext};
+
+/// A compact "time ago" for the last-seen column.
+fn ago(ms: i64) -> String {
+    let now = js_sys::Date::now() as i64;
+    let secs = ((now - ms) / 1000).max(0);
+    if secs < 60 {
+        "just now".to_string()
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86_400)
+    }
+}
+
+#[function_component(Exceptions)]
+pub fn exceptions() -> Html {
+    let data = use_state(|| None::<Result<Vec<GlobalException>, ApiError>>);
+    let range = use_state(Range::week);
+    let filter = use_context::<SearchContext>()
+        .map(|s| s.filter.clone())
+        .unwrap_or_default();
+
+    {
+        let data = data.clone();
+        let range = *range;
+        use_effect_with(range, move |_| {
+            spawn_local(async move {
+                data.set(Some(api::list_all_exceptions(&range.query()).await));
+            });
+            || ()
+        });
+    }
+
+    let set_range = {
+        let range = range.clone();
+        Callback::from(move |r: Range| range.set(r))
+    };
+
+    let body = match &*data {
+        None => html! { <p class="muted">{ "Loading…" }</p> },
+        Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
+        Some(Ok(list)) if list.is_empty() => {
+            html! { <div class="empty">{ "No exceptions reported in this period." }</div> }
+        }
+        Some(Ok(list)) => {
+            let rows = list
+                .iter()
+                .filter(|e| {
+                    let project = e.project_name.clone().unwrap_or_default();
+                    let status = status_label(e.group.status).to_lowercase();
+                    let source = e.source.to_lowercase();
+                    let text = format!(
+                        "{} {} {} {} {}",
+                        e.group.exc_type, e.group.sample_message, project, status, e.source
+                    )
+                    .to_lowercase();
+                    filter.matches(&MatchContext {
+                        project: &project,
+                        status: &status,
+                        source: &source,
+                        text: &text,
+                        ..Default::default()
+                    })
+                })
+                .map(row)
+                .collect::<Html>();
+
+            html! {
+                <div class="card-table">
+                    <table class="list">
+                        <thead><tr>
+                            <th>{ "Type" }</th><th>{ "Message" }</th><th>{ "Project" }</th>
+                            <th>{ "Count" }</th><th>{ "Last seen" }</th><th>{ "Status" }</th>
+                        </tr></thead>
+                        <tbody>{ rows }</tbody>
+                    </table>
+                </div>
+            }
+        }
+    };
+
+    html! {
+        <div class="page">
+            <PageHeader title="Exceptions"
+                subtitle="Recent crashes and errors across every project.">
+                <RangePicker value={*range} on_change={set_range} />
+            </PageHeader>
+            { body }
+        </div>
+    }
+}
+
+fn row(e: &GlobalException) -> Html {
+    // Link to the per-project detail only when the source is assigned to a project.
+    let type_cell = match &e.project_id {
+        Some(project) => html! {
+            <Link<Route> to={Route::Exception { project: project.clone(), group: e.group.group_id.clone() }}>
+                { &e.group.exc_type }
+            </Link<Route>>
+        },
+        None => html! { <span>{ &e.group.exc_type }</span> },
+    };
+    let project = match &e.project_name {
+        Some(name) => html! { { name } },
+        None => html! { <span class="badge badge--muted">{ "Unassigned" }</span> },
+    };
+
+    html! {
+        <tr>
+            <td>{ type_cell }</td>
+            <td class="ellipsis" title={e.group.sample_message.clone()}>{ &e.group.sample_message }</td>
+            <td>{ project }</td>
+            <td>{ e.group.count }</td>
+            <td class="muted">{ ago(e.group.last_seen_ms) }</td>
+            <td><span class={status_class(e.group.status)}>{ status_label(e.group.status) }</span></td>
+        </tr>
+    }
+}

--- a/ui/src/pages/misc.rs
+++ b/ui/src/pages/misc.rs
@@ -19,16 +19,16 @@ pub fn login() -> Html {
     // the configuration requirement instead of offering a dead-end button.
     if oidc_disabled() {
         return html! {
-            <div class="centered">
-                <h1>{ "Sign-in unavailable" }</h1>
-                <p class="muted">
-                    { "This server has no identity provider configured, so it cannot sign you in." }
-                </p>
-                <p class="muted">
-                    { "To run without OIDC, set an allow-expression admin ACL (e.g. " }
-                    <code>{ "acl: \"true\"" }</code>
-                    { ") so the dashboard is reachable without authentication." }
-                </p>
+            <div class="center-screen">
+                <div class="auth-card">
+                    <h1>{ "Sign-in unavailable" }</h1>
+                    <p>{ "This server has no identity provider configured, so it cannot sign you in." }</p>
+                    <p>
+                        { "To run without OIDC, set an allow-all admin ACL (" }
+                        <code>{ "acl: \"true\"" }</code>
+                        { ") so the dashboard is reachable without authentication." }
+                    </p>
+                </div>
             </div>
         };
     }
@@ -42,10 +42,12 @@ pub fn login() -> Html {
         })
     };
     html! {
-        <div class="centered">
-            <h1>{ "Sign in" }</h1>
-            <p class="muted">{ "Authentication is required to view the dashboard." }</p>
-            <button class="btn btn--primary" {onclick}>{ "Sign in" }</button>
+        <div class="center-screen">
+            <div class="auth-card">
+                <h1>{ "Sign in" }</h1>
+                <p>{ "Authentication is required to view the dashboard." }</p>
+                <button class="btn btn--primary" {onclick}>{ "Sign in with your identity provider" }</button>
+            </div>
         </div>
     }
 }
@@ -53,9 +55,11 @@ pub fn login() -> Html {
 #[function_component(NotFound)]
 pub fn not_found() -> Html {
     html! {
-        <div class="centered">
-            <h1>{ "404" }</h1>
-            <p class="muted">{ "That page could not be found." }</p>
+        <div class="center-screen">
+            <div class="auth-card">
+                <h1>{ "404" }</h1>
+                <p>{ "That page could not be found." }</p>
+            </div>
         </div>
     }
 }

--- a/ui/src/pages/mod.rs
+++ b/ui/src/pages/mod.rs
@@ -1,11 +1,17 @@
 mod exception_detail;
+mod exceptions;
 mod misc;
 mod overview;
-mod project;
+mod pixels;
+pub mod project;
+mod settings;
 mod sources;
 
 pub use exception_detail::ExceptionDetail;
+pub use exceptions::Exceptions;
 pub use misc::{Login, NotFound};
 pub use overview::Overview;
+pub use pixels::Pixels;
 pub use project::Project;
-pub use sources::Sources;
+pub use settings::Settings;
+pub use sources::ProjectSources;

--- a/ui/src/pages/overview.rs
+++ b/ui/src/pages/overview.rs
@@ -1,116 +1,193 @@
-use analytics_api::{Overview as OverviewData, ProjectInput};
+use analytics_api::{Overview as OverviewData, Project, SourceInput, source_label};
 use wasm_bindgen_futures::spawn_local;
-use web_sys::HtmlInputElement;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
 use crate::api::{self, ApiError};
 use crate::app::Route;
-use crate::components::{ApiErrorAlert, MetricCards, TimeSeriesChart};
+use crate::components::{
+    ApiErrorAlert, Dropdown, DropdownItem, MetricCards, PageHeader, ProjectsContext, Range,
+    RangePicker, TimeSeriesChart,
+};
+use crate::search::{MatchContext, SearchContext};
 
 #[function_component(Overview)]
 pub fn overview() -> Html {
     let data = use_state(|| None::<Result<OverviewData, ApiError>>);
     let reload = use_state(|| 0u32);
-    let new_name = use_state(String::new);
+    let range = use_state(Range::week);
+    let projects_ctx = use_context::<ProjectsContext>();
+    let filter = use_context::<SearchContext>()
+        .map(|s| s.filter.clone())
+        .unwrap_or_default();
 
     {
         let data = data.clone();
-        use_effect_with(*reload, move |_| {
+        let range = *range;
+        use_effect_with((*reload, range), move |_| {
             spawn_local(async move {
-                data.set(Some(api::overview("interval=day").await));
+                data.set(Some(api::overview(&range.query()).await));
             });
             || ()
         });
     }
 
-    let on_name = {
-        let new_name = new_name.clone();
-        Callback::from(move |e: InputEvent| {
-            let input: HtmlInputElement = e.target_unchecked_into();
-            new_name.set(input.value());
+    // Refresh both this page's data and the sidebar's project list.
+    let bump = {
+        let reload = reload.clone();
+        let sidebar = projects_ctx.as_ref().map(|c| c.reload.clone());
+        Callback::from(move |_: ()| {
+            reload.set(*reload + 1);
+            if let Some(sidebar) = &sidebar {
+                sidebar.emit(());
+            }
         })
     };
-    let on_create = {
-        let (new_name, reload) = (new_name.clone(), reload.clone());
-        Callback::from(move |_| {
-            let name = (*new_name).trim().to_string();
-            if name.is_empty() {
-                return;
+
+    let on_new = {
+        let open_new = projects_ctx.as_ref().map(|c| c.open_new.clone());
+        Callback::from(move |_: MouseEvent| {
+            if let Some(open_new) = &open_new {
+                open_new.emit(());
             }
-            let (new_name, reload) = (new_name.clone(), reload.clone());
+        })
+    };
+    let set_range = {
+        let range = range.clone();
+        Callback::from(move |r: Range| range.set(r))
+    };
+
+    let projects = projects_ctx
+        .as_ref()
+        .map(|c| c.projects.clone())
+        .unwrap_or_default();
+
+    let body = match &*data {
+        None => html! { <p class="muted">{ "Loading…" }</p> },
+        Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
+        Some(Ok(ov)) => {
+            let filtered_projects: Vec<_> = ov
+                .projects
+                .iter()
+                .filter(|p| {
+                    let text = p.project.name.to_lowercase();
+                    filter.matches(&MatchContext {
+                        project: &p.project.name,
+                        text: &text,
+                        ..Default::default()
+                    })
+                })
+                .collect();
+            let filtered_unassigned: Vec<_> = ov
+                .unassigned
+                .iter()
+                .filter(|u| {
+                    let text = u.uri.to_lowercase();
+                    filter.matches(&MatchContext {
+                        source: &u.uri,
+                        text: &text,
+                        ..Default::default()
+                    })
+                })
+                .collect();
+
+            let project_rows = filtered_projects.iter().map(|p| html! {
+                <tr>
+                    <td>
+                        <Link<Route> to={Route::Project { id: p.project.id.clone() }}>
+                            { &p.project.name }
+                        </Link<Route>>
+                    </td>
+                    <td>{ p.visitors }</td>
+                    <td>{ p.pageviews }</td>
+                </tr>
+            }).collect::<Html>();
+            let unassigned_rows = filtered_unassigned
+                .iter()
+                .map(|u| unassigned_row(&u.uri, u.visitors, u.pageviews, &projects, &bump))
+                .collect::<Html>();
+
+            html! {
+                <>
+                    <MetricCards summary={ov.summary.clone()} />
+                    <div class="panel"><TimeSeriesChart points={ov.timeseries.clone()} /></div>
+
+                    <section class="section">
+                        <h2 class="section__title">{ "Projects" }</h2>
+                        if ov.projects.is_empty() {
+                            <div class="empty">{ "No projects yet. Create one to start grouping your sources." }</div>
+                        } else if filtered_projects.is_empty() {
+                            <div class="empty">{ "No projects match your search." }</div>
+                        } else {
+                            <div class="card-table">
+                                <table class="list">
+                                    <thead><tr><th>{ "Project" }</th><th>{ "Visitors" }</th><th>{ "Page views" }</th></tr></thead>
+                                    <tbody>{ project_rows }</tbody>
+                                </table>
+                            </div>
+                        }
+                    </section>
+
+                    if !ov.unassigned.is_empty() {
+                        <section class="section">
+                            <h2 class="section__title">{ "Unassigned sources" }</h2>
+                            <p class="muted">{ "Reporting hostnames not yet grouped into a project." }</p>
+                            if filtered_unassigned.is_empty() {
+                                <div class="empty">{ "No sources match your search." }</div>
+                            } else {
+                                <div class="card-table">
+                                    <table class="list">
+                                        <thead><tr><th>{ "Source" }</th><th>{ "Visitors" }</th><th>{ "Page views" }</th><th>{ "Assign to" }</th></tr></thead>
+                                        <tbody>{ unassigned_rows }</tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+                    }
+                </>
+            }
+        }
+    };
+
+    html! {
+        <div class="page">
+            <PageHeader title="Overview" subtitle="Traffic across every project.">
+                <RangePicker value={*range} on_change={set_range} />
+                <button class="btn btn--primary" onclick={on_new}>{ "New project" }</button>
+            </PageHeader>
+            { body }
+        </div>
+    }
+}
+
+fn unassigned_row(
+    uri: &str,
+    visitors: i64,
+    pageviews: i64,
+    projects: &[Project],
+    bump: &Callback<()>,
+) -> Html {
+    let items: Vec<DropdownItem> =
+        projects.iter().map(|p| DropdownItem::new(p.id.clone(), p.name.clone())).collect();
+    let on_select = {
+        let (uri, bump) = (uri.to_string(), bump.clone());
+        Callback::from(move |project_id: String| {
+            let input = SourceInput { project_id: Some(project_id), ..Default::default() };
+            let (uri, bump) = (uri.clone(), bump.clone());
             spawn_local(async move {
-                if api::create_project(&ProjectInput { name, slug: None }).await.is_ok() {
-                    new_name.set(String::new());
-                    reload.set(*reload + 1);
+                if api::update_source(&uri, &input).await.is_ok() {
+                    bump.emit(());
                 }
             });
         })
     };
 
-    match &*data {
-        None => html! { <p class="muted">{ "Loading…" }</p> },
-        Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
-        Some(Ok(overview)) => html! {
-            <div class="page">
-                <h1>{ "Overview" }</h1>
-                <MetricCards summary={overview.summary.clone()} />
-                <div class="panel">
-                    <TimeSeriesChart points={overview.timeseries.clone()} />
-                </div>
-
-                <h2>{ "Projects" }</h2>
-                <div class="form-row">
-                    <input class="input" placeholder="New project name" value={(*new_name).clone()} oninput={on_name} />
-                    <button class="btn btn--primary" onclick={on_create}>{ "Create project" }</button>
-                </div>
-                if overview.projects.is_empty() {
-                    <p class="muted">{ "No projects yet." }</p>
-                } else {
-                    <table class="list">
-                        <thead><tr><th>{ "Project" }</th><th>{ "Visitors" }</th><th>{ "Page views" }</th><th></th></tr></thead>
-                        <tbody>
-                        { for overview.projects.iter().map(|p| {
-                            let on_delete = {
-                                let (id, reload) = (p.project.id.clone(), reload.clone());
-                                Callback::from(move |_| {
-                                    let (id, reload) = (id.clone(), reload.clone());
-                                    spawn_local(async move {
-                                        if api::delete_project(&id).await.is_ok() {
-                                            reload.set(*reload + 1);
-                                        }
-                                    });
-                                })
-                            };
-                            html! {
-                                <tr>
-                                    <td><Link<Route> to={Route::Project { id: p.project.id.clone() }}>{ &p.project.name }</Link<Route>></td>
-                                    <td>{ p.visitors }</td>
-                                    <td>{ p.pageviews }</td>
-                                    <td><button class="btn btn--ghost" onclick={on_delete}>{ "Delete" }</button></td>
-                                </tr>
-                            }
-                        }) }
-                        </tbody>
-                    </table>
-                }
-
-                if !overview.unassigned.is_empty() {
-                    <>
-                        <h2>{ "Unassigned sources" }</h2>
-                        <p class="muted">{ "Reporting hostnames not yet grouped into a project." }</p>
-                        <table class="list">
-                            <thead><tr><th>{ "Source" }</th><th>{ "Visitors" }</th><th>{ "Page views" }</th></tr></thead>
-                            <tbody>
-                            { for overview.unassigned.iter().map(|u| html! {
-                                <tr><td>{ &u.uri }</td><td>{ u.visitors }</td><td>{ u.pageviews }</td></tr>
-                            }) }
-                            </tbody>
-                        </table>
-                        <p><Link<Route> to={Route::Sources}>{ "Manage sources →" }</Link<Route>></p>
-                    </>
-                }
-            </div>
-        },
+    html! {
+        <tr>
+            <td><code>{ source_label(uri) }</code></td>
+            <td>{ visitors }</td>
+            <td>{ pageviews }</td>
+            <td><Dropdown items={items} value="" placeholder="Assign…" on_select={on_select} /></td>
+        </tr>
     }
 }

--- a/ui/src/pages/pixels.rs
+++ b/ui/src/pages/pixels.rs
@@ -1,0 +1,382 @@
+//! The global Tracking Pixels page: every pixel across all projects. Creation and
+//! editing (including the event-metadata payload) happen in a drawer.
+
+use std::collections::BTreeMap;
+
+use analytics_api::{Pixel, PixelInput};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+use crate::api::{self, ApiError};
+use crate::components::{ApiErrorAlert, Drawer, Dropdown, DropdownItem, PageHeader, ProjectsContext};
+use crate::search::{MatchContext, SearchContext};
+
+fn input_value(e: &InputEvent) -> String {
+    e.target_unchecked_into::<HtmlInputElement>().value()
+}
+
+#[function_component(Pixels)]
+pub fn pixels() -> Html {
+    let pixels = use_state(|| None::<Result<Vec<Pixel>, ApiError>>);
+    let reload = use_state(|| 0u32);
+    let projects = use_context::<ProjectsContext>()
+        .map(|c| c.projects.clone())
+        .unwrap_or_default();
+    let filter = use_context::<SearchContext>()
+        .map(|s| s.filter.clone())
+        .unwrap_or_default();
+
+    // Drawer + form state (edit_id = None means "create").
+    let open = use_state(|| false);
+    let edit_id = use_state(|| None::<String>);
+    let f_name = use_state(String::new);
+    let f_event = use_state(String::new);
+    let f_project = use_state(String::new);
+    let f_meta = use_state(Vec::<(String, String)>::new);
+    let f_error = use_state(|| None::<String>);
+    let submitting = use_state(|| false);
+
+    {
+        let pixels = pixels.clone();
+        use_effect_with(*reload, move |_| {
+            spawn_local(async move {
+                pixels.set(Some(api::list_all_pixels().await));
+            });
+            || ()
+        });
+    }
+
+    let origin = web_sys::window()
+        .and_then(|w| w.location().origin().ok())
+        .unwrap_or_default();
+
+    let project_name = {
+        let projects = projects.clone();
+        move |id: &str| -> String {
+            projects.iter().find(|p| p.id == id).map(|p| p.name.clone()).unwrap_or_else(|| id.to_string())
+        }
+    };
+
+    let open_new = {
+        let (open, edit_id, f_name, f_event, f_project, f_meta, f_error) = (
+            open.clone(), edit_id.clone(), f_name.clone(), f_event.clone(),
+            f_project.clone(), f_meta.clone(), f_error.clone(),
+        );
+        let first_project = projects.first().map(|p| p.id.clone()).unwrap_or_default();
+        Callback::from(move |_: MouseEvent| {
+            edit_id.set(None);
+            f_name.set(String::new());
+            f_event.set(String::new());
+            f_project.set(first_project.clone());
+            f_meta.set(Vec::new());
+            f_error.set(None);
+            open.set(true);
+        })
+    };
+
+    let open_edit = {
+        let (open, edit_id, f_name, f_event, f_project, f_meta, f_error) = (
+            open.clone(), edit_id.clone(), f_name.clone(), f_event.clone(),
+            f_project.clone(), f_meta.clone(), f_error.clone(),
+        );
+        move |pixel: &Pixel| {
+            edit_id.set(Some(pixel.id.clone()));
+            f_name.set(pixel.name.clone());
+            f_event.set(pixel.event_name.clone());
+            f_project.set(pixel.project_id.clone());
+            f_meta.set(pixel.metadata.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+            f_error.set(None);
+            open.set(true);
+        }
+    };
+
+    let close = {
+        let open = open.clone();
+        Callback::from(move |_| open.set(false))
+    };
+
+    let on_save = {
+        let (open, edit_id, f_name, f_event, f_project, f_meta, f_error, submitting, reload) = (
+            open.clone(), edit_id.clone(), f_name.clone(), f_event.clone(), f_project.clone(),
+            f_meta.clone(), f_error.clone(), submitting.clone(), reload.clone(),
+        );
+        Callback::from(move |_: MouseEvent| {
+            let name = (*f_name).trim().to_string();
+            if name.is_empty() {
+                f_error.set(Some("A pixel name is required.".to_string()));
+                return;
+            }
+            let mut metadata = BTreeMap::new();
+            for (k, v) in (*f_meta).iter() {
+                let key = k.trim();
+                if !key.is_empty() {
+                    metadata.insert(key.to_string(), v.clone());
+                }
+            }
+            let input = PixelInput {
+                name,
+                event_name: Some((*f_event).trim().to_string()).filter(|e| !e.is_empty()),
+                metadata,
+            };
+            let id = (*edit_id).clone();
+            let project = (*f_project).clone();
+            if id.is_none() && project.is_empty() {
+                f_error.set(Some("Choose a project for the pixel.".to_string()));
+                return;
+            }
+            let (open, f_error, submitting, reload) =
+                (open.clone(), f_error.clone(), submitting.clone(), reload.clone());
+            submitting.set(true);
+            spawn_local(async move {
+                let result = match &id {
+                    Some(id) => api::update_pixel(id, &input).await,
+                    None => api::create_pixel(&project, &input).await,
+                };
+                match result {
+                    Ok(_) => {
+                        reload.set(*reload + 1);
+                        open.set(false);
+                    }
+                    Err(err) => f_error.set(Some(err.to_string())),
+                }
+                submitting.set(false);
+            });
+        })
+    };
+
+    let body = match &*pixels {
+        None => html! { <p class="muted">{ "Loading…" }</p> },
+        Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
+        Some(Ok(list)) if list.is_empty() => {
+            html! { <div class="empty">{ "No tracking pixels yet." }</div> }
+        }
+        Some(Ok(list)) => {
+            let filtered: Vec<_> = list
+                .iter()
+                .filter(|p| {
+                    let proj = project_name(&p.project_id);
+                    let text = format!("{} {} {}", p.name, proj, p.event_name).to_lowercase();
+                    filter.matches(&MatchContext { project: &proj, text: &text, ..Default::default() })
+                })
+                .collect();
+            let rows = filtered.iter().map(|p| {
+                let url = format!("{origin}/track/gif/{}.gif", p.id);
+                let on_edit = {
+                    let (open_edit, pixel) = (open_edit.clone(), (*p).clone());
+                    Callback::from(move |_| open_edit(&pixel))
+                };
+                let on_delete = {
+                    let (pid, reload) = (p.id.clone(), reload.clone());
+                    Callback::from(move |_| {
+                        let (pid, reload) = (pid.clone(), reload.clone());
+                        spawn_local(async move {
+                            if api::delete_pixel(&pid).await.is_ok() {
+                                reload.set(*reload + 1);
+                            }
+                        });
+                    })
+                };
+                html! {
+                    <tr>
+                        <td>{ &p.name }</td>
+                        <td>{ project_name(&p.project_id) }</td>
+                        <td>{ &p.event_name }</td>
+                        <td><code class="embed">{ url }</code></td>
+                        <td class="row-actions">
+                            <button class="btn btn--small btn--ghost" onclick={on_edit}>{ "Edit" }</button>
+                            <button class="btn btn--small btn--ghost" onclick={on_delete}>{ "Delete" }</button>
+                        </td>
+                    </tr>
+                }
+            }).collect::<Html>();
+
+            if filtered.is_empty() {
+                html! { <div class="empty">{ "No pixels match your search." }</div> }
+            } else {
+                html! {
+                    <div class="card-table">
+                        <table class="list">
+                            <thead><tr><th>{ "Name" }</th><th>{ "Project" }</th><th>{ "Event" }</th><th>{ "Embed URL" }</th><th></th></tr></thead>
+                            <tbody>{ rows }</tbody>
+                        </table>
+                    </div>
+                }
+            }
+        }
+    };
+
+    let no_projects = projects.is_empty();
+    let drawer = pixel_drawer(PixelDrawerArgs {
+        open: *open,
+        editing: (*edit_id).is_some(),
+        projects: &projects,
+        project_name: &project_name,
+        f_name: f_name.clone(),
+        f_event: f_event.clone(),
+        f_project: f_project.clone(),
+        f_meta: f_meta.clone(),
+        error: (*f_error).clone(),
+        submitting: *submitting,
+        on_close: close,
+        on_save,
+    });
+
+    html! {
+        <div class="page">
+            <PageHeader title="Tracking pixels"
+                subtitle="1×1 GIF beacons for email opens, RSS, and other no-JavaScript contexts.">
+                <button class="btn btn--primary" onclick={open_new} disabled={no_projects}>{ "New pixel" }</button>
+            </PageHeader>
+            if no_projects {
+                <p class="muted">{ "Create a project first — every pixel belongs to one." }</p>
+            }
+            { body }
+            { drawer }
+        </div>
+    }
+}
+
+struct PixelDrawerArgs<'a, F: Fn(&str) -> String> {
+    open: bool,
+    editing: bool,
+    projects: &'a [analytics_api::Project],
+    project_name: &'a F,
+    f_name: UseStateHandle<String>,
+    f_event: UseStateHandle<String>,
+    f_project: UseStateHandle<String>,
+    f_meta: UseStateHandle<Vec<(String, String)>>,
+    error: Option<String>,
+    submitting: bool,
+    on_close: Callback<()>,
+    on_save: Callback<MouseEvent>,
+}
+
+fn pixel_drawer<F: Fn(&str) -> String>(a: PixelDrawerArgs<F>) -> Html {
+    let title = if a.editing { "Edit pixel" } else { "New pixel" };
+
+    let on_name = {
+        let f = a.f_name.clone();
+        Callback::from(move |e: InputEvent| f.set(input_value(&e)))
+    };
+    let on_event = {
+        let f = a.f_event.clone();
+        Callback::from(move |e: InputEvent| f.set(input_value(&e)))
+    };
+
+    let project_field = if a.editing {
+        html! {
+            <div class="field">
+                <label class="field__label">{ "Project" }</label>
+                <p class="drawer__hint">{ (a.project_name)(&a.f_project) }</p>
+            </div>
+        }
+    } else {
+        let items: Vec<DropdownItem> =
+            a.projects.iter().map(|p| DropdownItem::new(p.id.clone(), p.name.clone())).collect();
+        let on_select = {
+            let f = a.f_project.clone();
+            Callback::from(move |v: String| f.set(v))
+        };
+        html! {
+            <div class="field">
+                <label class="field__label">{ "Project" }</label>
+                <Dropdown block=true items={items} value={(*a.f_project).clone()}
+                    placeholder="Choose a project" {on_select} />
+            </div>
+        }
+    };
+
+    // Metadata key/value editor.
+    let meta_rows = (*a.f_meta).iter().enumerate().map(|(i, (k, v))| {
+        let on_key = {
+            let f = a.f_meta.clone();
+            Callback::from(move |e: InputEvent| {
+                let mut m = (*f).clone();
+                if let Some(row) = m.get_mut(i) { row.0 = input_value(&e); }
+                f.set(m);
+            })
+        };
+        let on_val = {
+            let f = a.f_meta.clone();
+            Callback::from(move |e: InputEvent| {
+                let mut m = (*f).clone();
+                if let Some(row) = m.get_mut(i) { row.1 = input_value(&e); }
+                f.set(m);
+            })
+        };
+        let on_remove = {
+            let f = a.f_meta.clone();
+            Callback::from(move |_| {
+                let mut m = (*f).clone();
+                if i < m.len() { m.remove(i); }
+                f.set(m);
+            })
+        };
+        html! {
+            <div class="kv-editor__row">
+                <input class="input" placeholder="key" value={k.clone()} oninput={on_key} />
+                <input class="input" placeholder="value" value={v.clone()} oninput={on_val} />
+                <button class="kv-editor__remove" aria-label="Remove field" onclick={on_remove}>
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12" /></svg>
+                </button>
+            </div>
+        }
+    }).collect::<Html>();
+
+    let on_add = {
+        let f = a.f_meta.clone();
+        Callback::from(move |_| {
+            let mut m = (*f).clone();
+            m.push((String::new(), String::new()));
+            f.set(m);
+        })
+    };
+
+    let error = a
+        .error
+        .map(|e| html! { <p class="drawer__hint" style="color: var(--danger);">{ e }</p> });
+
+    let footer = {
+        let on_cancel = {
+            let close = a.on_close.clone();
+            Callback::from(move |_: MouseEvent| close.emit(()))
+        };
+        let save_label = if a.submitting {
+            "Saving…"
+        } else if a.editing {
+            "Save changes"
+        } else {
+            "Create pixel"
+        };
+        html! {
+            <>
+                <button class="btn btn--ghost" onclick={on_cancel}>{ "Cancel" }</button>
+                <button class="btn btn--primary" onclick={a.on_save} disabled={a.submitting}>{ save_label }</button>
+            </>
+        }
+    };
+
+    html! {
+        <Drawer open={a.open} title={title} on_close={a.on_close} footer={footer}>
+            <div class="field">
+                <label class="field__label">{ "Name" }</label>
+                <input class="input" placeholder="e.g. June newsletter" value={(*a.f_name).clone()} oninput={on_name} />
+            </div>
+            <div class="field">
+                <label class="field__label">{ "Event name" }</label>
+                <input class="input" placeholder="default: pixel" value={(*a.f_event).clone()} oninput={on_event} />
+            </div>
+            { project_field }
+            <div class="field">
+                <label class="field__label">{ "Event metadata" }</label>
+                <div class="kv-editor">
+                    { meta_rows }
+                    <button class="btn btn--small" onclick={on_add}>{ "Add field" }</button>
+                </div>
+            </div>
+            { error }
+        </Drawer>
+    }
+}

--- a/ui/src/pages/project.rs
+++ b/ui/src/pages/project.rs
@@ -1,12 +1,15 @@
-use analytics_api::{ExceptionGroup, ExceptionStatus, Pixel, PixelInput, Project as ProjectData, Stats};
+use analytics_api::{ExceptionGroup, ExceptionStatus, Project as ProjectData, Stats};
 use wasm_bindgen_futures::spawn_local;
-use web_sys::HtmlInputElement;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
 use crate::api::{self, ApiError};
 use crate::app::Route;
-use crate::components::{ApiErrorAlert, Breakdown, MetricCards, TimeSeriesChart};
+use crate::components::{
+    ApiErrorAlert, Breakdown, Crumb, MetricCards, PageHeader, Range, RangePicker, TimeSeriesChart,
+};
+use crate::pages::ProjectSources;
+use crate::search::{MatchContext, SearchContext, SearchVocabulary, VocabularyContext};
 
 #[derive(Properties, PartialEq)]
 pub struct ProjectProps {
@@ -16,7 +19,7 @@ pub struct ProjectProps {
 #[derive(Clone, Copy, PartialEq)]
 enum Tab {
     Stats,
-    Pixels,
+    Sources,
     Exceptions,
 }
 
@@ -25,6 +28,7 @@ pub fn project(props: &ProjectProps) -> Html {
     let id = props.id.clone();
     let project = use_state(|| None::<Result<ProjectData, ApiError>>);
     let tab = use_state(|| Tab::Stats);
+    let range = use_state(Range::week);
 
     {
         let project = project.clone();
@@ -51,23 +55,36 @@ pub fn project(props: &ProjectProps) -> Html {
         }
     };
 
+    // The lookback applies to the statistics and exceptions tabs.
+    let show_range = !matches!(*tab, Tab::Sources);
+    let set_range = {
+        let range = range.clone();
+        Callback::from(move |r: Range| range.set(r))
+    };
+
     html! {
         <div class="page">
-            <p class="crumb"><Link<Route> to={Route::Overview}>{ "← Overview" }</Link<Route>></p>
-            <h1>{ name }</h1>
+            <PageHeader
+                crumbs={vec![Crumb::link("Overview", Route::Overview), Crumb::current(name.clone())]}
+                title={name.clone()}
+            >
+                if show_range {
+                    <RangePicker value={*range} on_change={set_range} />
+                }
+            </PageHeader>
             if let Some(Err(err)) = &*project {
                 <ApiErrorAlert error={err.clone()} />
             }
             <div class="tabs">
                 { tab_button(Tab::Stats, "Statistics") }
-                { tab_button(Tab::Pixels, "Tracking pixels") }
+                { tab_button(Tab::Sources, "Sources") }
                 { tab_button(Tab::Exceptions, "Exceptions") }
             </div>
             {
                 match *tab {
-                    Tab::Stats => html! { <ProjectStats id={id.clone()} /> },
-                    Tab::Pixels => html! { <ProjectPixels id={id.clone()} /> },
-                    Tab::Exceptions => html! { <ProjectExceptions id={id.clone()} /> },
+                    Tab::Stats => html! { <ProjectStats id={id.clone()} range={*range} /> },
+                    Tab::Sources => html! { <ProjectSources id={id.clone()} /> },
+                    Tab::Exceptions => html! { <ProjectExceptions id={id.clone()} range={*range} /> },
                 }
             }
         </div>
@@ -75,22 +92,52 @@ pub fn project(props: &ProjectProps) -> Html {
 }
 
 #[derive(Properties, PartialEq)]
-struct IdProps {
+struct TabProps {
     id: String,
+    range: Range,
 }
 
 #[function_component(ProjectStats)]
-fn project_stats(props: &IdProps) -> Html {
+fn project_stats(props: &TabProps) -> Html {
     let id = props.id.clone();
+    let range = props.range;
     let stats = use_state(|| None::<Result<Stats, ApiError>>);
+    let vocabulary = use_context::<VocabularyContext>();
     {
         let stats = stats.clone();
-        use_effect_with(id.clone(), move |id| {
-            let id = id.clone();
+        use_effect_with((id.clone(), range), move |(id, range)| {
+            let (id, query) = (id.clone(), range.query());
             spawn_local(async move {
-                stats.set(Some(api::project_stats(&id, "interval=day").await));
+                stats.set(Some(api::project_stats(&id, &query).await));
             });
             || ()
+        });
+    }
+
+    // Publish page/source names so the app-bar can complete `page:` / `source:`.
+    let pages_vocab: Vec<AttrValue> = match &*stats {
+        Some(Ok(s)) => s.pages.iter().map(|k| AttrValue::from(k.key.clone())).collect(),
+        _ => Vec::new(),
+    };
+    let sources_vocab: Vec<AttrValue> = match &*stats {
+        Some(Ok(s)) => s.sources.iter().map(|k| AttrValue::from(k.key.clone())).collect(),
+        _ => Vec::new(),
+    };
+    {
+        let vocabulary = vocabulary.clone();
+        let (pv, sv) = (pages_vocab.clone(), sources_vocab.clone());
+        use_effect_with((pv.clone(), sv.clone()), move |_| {
+            if let Some(vocabulary) = &vocabulary {
+                vocabulary.set.emit(SearchVocabulary { pages: pv, sources: sv, statuses: Vec::new() });
+            }
+            // Clear our contribution on unmount so its completions don't leak to
+            // pages that publish no vocabulary (e.g. the overview).
+            let cleanup = vocabulary.clone();
+            move || {
+                if let Some(cleanup) = &cleanup {
+                    cleanup.set.emit(SearchVocabulary::default());
+                }
+            }
         });
     }
 
@@ -116,149 +163,87 @@ fn project_stats(props: &IdProps) -> Html {
     }
 }
 
-#[function_component(ProjectPixels)]
-fn project_pixels(props: &IdProps) -> Html {
+#[function_component(ProjectExceptions)]
+fn project_exceptions(props: &TabProps) -> Html {
     let id = props.id.clone();
-    let pixels = use_state(|| None::<Result<Vec<Pixel>, ApiError>>);
-    let reload = use_state(|| 0u32);
-    let name = use_state(String::new);
-    let event = use_state(String::new);
-
+    let range = props.range;
+    let groups = use_state(|| None::<Result<Vec<ExceptionGroup>, ApiError>>);
+    let vocabulary = use_context::<VocabularyContext>();
+    let filter = use_context::<SearchContext>()
+        .map(|s| s.filter.clone())
+        .unwrap_or_default();
     {
-        let pixels = pixels.clone();
-        let id = id.clone();
-        use_effect_with((id.clone(), *reload), move |(id, _)| {
-            let id = id.clone();
+        let groups = groups.clone();
+        use_effect_with((id.clone(), range), move |(id, range)| {
+            let (id, query) = (id.clone(), range.query());
             spawn_local(async move {
-                pixels.set(Some(api::list_pixels(&id).await));
+                groups.set(Some(api::list_exceptions(&id, &query).await));
             });
             || ()
         });
     }
 
-    let origin = web_sys::window()
-        .and_then(|w| w.location().origin().ok())
-        .unwrap_or_default();
-
-    let on_name = bind_input(name.clone());
-    let on_event = bind_input(event.clone());
-
-    let on_create = {
-        let (id, name, event, reload) = (id.clone(), name.clone(), event.clone(), reload.clone());
-        Callback::from(move |_| {
-            let title = (*name).trim().to_string();
-            if title.is_empty() {
-                return;
-            }
-            let input = PixelInput {
-                name: title,
-                event_name: Some((*event).trim().to_string()).filter(|e| !e.is_empty()),
-                metadata: Default::default(),
-            };
-            let (id, name, event, reload) = (id.clone(), name.clone(), event.clone(), reload.clone());
-            spawn_local(async move {
-                if api::create_pixel(&id, &input).await.is_ok() {
-                    name.set(String::new());
-                    event.set(String::new());
-                    reload.set(*reload + 1);
-                }
-            });
-        })
-    };
-
-    html! {
-        <>
-            <div class="form-row">
-                <input class="input" placeholder="Pixel name (e.g. June newsletter)" value={(*name).clone()} oninput={on_name} />
-                <input class="input" placeholder="Event name (default: pixel)" value={(*event).clone()} oninput={on_event} />
-                <button class="btn btn--primary" onclick={on_create}>{ "Create pixel" }</button>
-            </div>
-            {
-                match &*pixels {
-                    None => html! { <p class="muted">{ "Loading…" }</p> },
-                    Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
-                    Some(Ok(list)) if list.is_empty() => html! { <p class="muted">{ "No pixels yet." }</p> },
-                    Some(Ok(list)) => html! {
-                        <table class="list">
-                            <thead><tr><th>{ "Name" }</th><th>{ "Event" }</th><th>{ "Embed URL" }</th><th></th></tr></thead>
-                            <tbody>
-                            { for list.iter().map(|p| {
-                                let url = format!("{origin}/track/gif/{}.gif", p.id);
-                                let on_delete = {
-                                    let (pid, reload) = (p.id.clone(), reload.clone());
-                                    Callback::from(move |_| {
-                                        let (pid, reload) = (pid.clone(), reload.clone());
-                                        spawn_local(async move {
-                                            if api::delete_pixel(&pid).await.is_ok() {
-                                                reload.set(*reload + 1);
-                                            }
-                                        });
-                                    })
-                                };
-                                html! {
-                                    <tr>
-                                        <td>{ &p.name }</td>
-                                        <td>{ &p.event_name }</td>
-                                        <td><code class="embed">{ url }</code></td>
-                                        <td><button class="btn btn--ghost" onclick={on_delete}>{ "Delete" }</button></td>
-                                    </tr>
-                                }
-                            }) }
-                            </tbody>
-                        </table>
-                    },
-                }
-            }
-        </>
-    }
-}
-
-#[function_component(ProjectExceptions)]
-fn project_exceptions(props: &IdProps) -> Html {
-    let id = props.id.clone();
-    let groups = use_state(|| None::<Result<Vec<ExceptionGroup>, ApiError>>);
+    // Offer the exception statuses for `status:` completion.
     {
-        let groups = groups.clone();
-        use_effect_with(id.clone(), move |id| {
-            let id = id.clone();
-            spawn_local(async move {
-                groups.set(Some(api::list_exceptions(&id, "interval=day").await));
-            });
-            || ()
+        let vocabulary = vocabulary.clone();
+        use_effect_with((), move |_| {
+            if let Some(vocabulary) = &vocabulary {
+                vocabulary.set.emit(SearchVocabulary {
+                    statuses: vec!["unresolved".into(), "resolved".into(), "ignored".into()],
+                    ..Default::default()
+                });
+            }
+            let cleanup = vocabulary.clone();
+            move || {
+                if let Some(cleanup) = &cleanup {
+                    cleanup.set.emit(SearchVocabulary::default());
+                }
+            }
         });
     }
 
     match &*groups {
         None => html! { <p class="muted">{ "Loading…" }</p> },
         Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
-        Some(Ok(list)) if list.is_empty() => html! { <p class="muted">{ "No exceptions reported." }</p> },
-        Some(Ok(list)) => html! {
-            <table class="list">
-                <thead><tr><th>{ "Type" }</th><th>{ "Message" }</th><th>{ "Count" }</th><th>{ "Status" }</th></tr></thead>
-                <tbody>
-                { for list.iter().map(|g| html! {
-                    <tr>
-                        <td>
-                            <Link<Route> to={Route::Exception { project: id.clone(), group: g.group_id.clone() }}>
-                                { &g.exc_type }
-                            </Link<Route>>
-                        </td>
-                        <td class="ellipsis" title={g.sample_message.clone()}>{ &g.sample_message }</td>
-                        <td>{ g.count }</td>
-                        <td><span class={status_class(g.status)}>{ status_label(g.status) }</span></td>
-                    </tr>
-                }) }
-                </tbody>
-            </table>
-        },
-    }
-}
+        Some(Ok(list)) if list.is_empty() => {
+            html! { <div class="empty">{ "No exceptions reported." }</div> }
+        }
+        Some(Ok(list)) => {
+            let filtered: Vec<_> = list
+                .iter()
+                .filter(|g| {
+                    let status = status_label(g.status).to_lowercase();
+                    let text = format!("{} {} {}", g.exc_type, g.sample_message, status).to_lowercase();
+                    filter.matches(&MatchContext { status: &status, text: &text, ..Default::default() })
+                })
+                .collect();
+            let rows = filtered.iter().map(|g| html! {
+                <tr>
+                    <td>
+                        <Link<Route> to={Route::Exception { project: id.clone(), group: g.group_id.clone() }}>
+                            { &g.exc_type }
+                        </Link<Route>>
+                    </td>
+                    <td class="ellipsis" title={g.sample_message.clone()}>{ &g.sample_message }</td>
+                    <td>{ g.count }</td>
+                    <td><span class={status_class(g.status)}>{ status_label(g.status) }</span></td>
+                </tr>
+            }).collect::<Html>();
 
-fn bind_input(state: UseStateHandle<String>) -> Callback<InputEvent> {
-    Callback::from(move |e: InputEvent| {
-        let input: HtmlInputElement = e.target_unchecked_into();
-        state.set(input.value());
-    })
+            if filtered.is_empty() {
+                html! { <div class="empty">{ "No exceptions match your search." }</div> }
+            } else {
+                html! {
+                    <div class="card-table">
+                        <table class="list">
+                            <thead><tr><th>{ "Type" }</th><th>{ "Message" }</th><th>{ "Count" }</th><th>{ "Status" }</th></tr></thead>
+                            <tbody>{ rows }</tbody>
+                        </table>
+                    </div>
+                }
+            }
+        }
+    }
 }
 
 pub fn status_label(status: ExceptionStatus) -> &'static str {

--- a/ui/src/pages/settings.rs
+++ b/ui/src/pages/settings.rs
@@ -1,0 +1,198 @@
+//! The Settings page: signed-in account, instance/runtime info (authenticated, so
+//! it may reveal the version), the tracker install snippet, and a danger zone.
+
+use analytics_api::Instance;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use crate::api::{self, ApiError};
+use crate::app::AuthHandle;
+use crate::components::{ApiErrorAlert, Dropdown, DropdownItem, PageHeader, ProjectsContext, icons};
+
+#[function_component(Settings)]
+pub fn settings() -> Html {
+    html! {
+        <div class="page">
+            <PageHeader title="Settings" subtitle="Your account, this instance, and onboarding." />
+            <div class="settings">
+                <AccountCard />
+                <InstanceCard />
+                <TrackerCard />
+                <DangerZone />
+            </div>
+        </div>
+    }
+}
+
+#[function_component(AccountCard)]
+fn account_card() -> Html {
+    let auth = use_context::<AuthHandle>();
+    let body = match auth.as_ref().and_then(|a| a.user.clone()) {
+        Some(user) => {
+            let email = user
+                .email
+                .map(|e| html! { <><span class="kv__key">{ "Email" }</span><span class="kv__val">{ e }</span></> });
+            html! {
+                <div class="kv">
+                    <span class="kv__key">{ "Name" }</span>
+                    <span class="kv__val">{ user.name }</span>
+                    { email }
+                </div>
+            }
+        }
+        None => {
+            html! { <p class="muted">{ "Authentication is disabled on this server; no account is associated with this session." }</p> }
+        }
+    };
+    html! {
+        <div class="settings-card">
+            <h2 class="settings-card__title">{ "Account" }</h2>
+            { body }
+        </div>
+    }
+}
+
+#[function_component(InstanceCard)]
+fn instance_card() -> Html {
+    let instance = use_state(|| None::<Result<Instance, ApiError>>);
+    {
+        let instance = instance.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                instance.set(Some(api::instance().await));
+            });
+            || ()
+        });
+    }
+
+    let body = match &*instance {
+        None => html! { <p class="muted">{ "Loading…" }</p> },
+        Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
+        Some(Ok(i)) => {
+            let rate = if i.rate_limiting {
+                format!("{} req/min tracking · {} req/min unauthenticated", i.tracking_per_minute, i.unauthenticated_per_minute)
+            } else {
+                "Disabled".to_string()
+            };
+            html! {
+                <div class="kv">
+                    <span class="kv__key">{ "Version" }</span>
+                    <span class="kv__val">{ &i.version }</span>
+                    <span class="kv__key">{ "Data retention" }</span>
+                    <span class="kv__val">{ format!("{} days", i.retention_days) }</span>
+                    <span class="kv__key">{ "Hot window" }</span>
+                    <span class="kv__val">{ format!("{} hours", i.hot_window_hours) }</span>
+                    <span class="kv__key">{ "Honour DNT / GPC" }</span>
+                    <span class="kv__val">{ if i.honor_dnt { "Yes" } else { "No" } }</span>
+                    <span class="kv__key">{ "Rate limiting" }</span>
+                    <span class="kv__val">{ rate }</span>
+                    <span class="kv__key">{ "Max auto-sources" }</span>
+                    <span class="kv__val">{ i.max_auto_sources }</span>
+                </div>
+            }
+        }
+    };
+    html! {
+        <div class="settings-card">
+            <h2 class="settings-card__title">{ "Instance" }</h2>
+            <p class="settings-card__desc">{ "Runtime configuration of this analytics server." }</p>
+            { body }
+        </div>
+    }
+}
+
+#[function_component(TrackerCard)]
+fn tracker_card() -> Html {
+    let origin = web_sys::window()
+        .and_then(|w| w.location().origin().ok())
+        .unwrap_or_else(|| "https://analytics.example.com".to_string());
+
+    let snippet = format!(
+        "<script\n  async\n  src=\"{origin}/tracker.js\"\n  data-api=\"{origin}\"\n  data-auto-capture-exceptions=\"true\"\n></script>"
+    );
+
+    let on_copy = {
+        let snippet = snippet.clone();
+        Callback::from(move |_| {
+            if let Some(win) = web_sys::window() {
+                let _ = win.navigator().clipboard().write_text(&snippet);
+            }
+        })
+    };
+
+    html! {
+        <div class="settings-card">
+            <h2 class="settings-card__title">{ "Install the tracker" }</h2>
+            <p class="settings-card__desc">
+                { "Add this snippet to your site. Sources are identified by hostname — no per-site key to embed." }
+            </p>
+            <pre class="snippet">
+                <button class="btn btn--small snippet__copy" onclick={on_copy}>
+                    <span class="menu__icon">{ icons::copy() }</span>{ "Copy" }
+                </button>
+                { snippet }
+            </pre>
+        </div>
+    }
+}
+
+#[function_component(DangerZone)]
+fn danger_zone() -> Html {
+    let projects_ctx = use_context::<ProjectsContext>();
+    let selected = use_state(String::new);
+    let projects = projects_ctx.as_ref().map(|c| c.projects.clone()).unwrap_or_default();
+
+    let on_select = {
+        let selected = selected.clone();
+        Callback::from(move |value: String| selected.set(value))
+    };
+    let items: Vec<DropdownItem> =
+        projects.iter().map(|p| DropdownItem::new(p.id.clone(), p.name.clone())).collect();
+
+    let on_delete = {
+        let selected = selected.clone();
+        let reload = projects_ctx.as_ref().map(|c| c.reload.clone());
+        Callback::from(move |_| {
+            let id = (*selected).clone();
+            if id.is_empty() {
+                return;
+            }
+            let confirmed = web_sys::window()
+                .and_then(|w| {
+                    w.confirm_with_message(
+                        "Delete this project? Its pixels are removed and its sources become unassigned. This cannot be undone.",
+                    )
+                    .ok()
+                })
+                .unwrap_or(false);
+            if !confirmed {
+                return;
+            }
+            let (selected, reload) = (selected.clone(), reload.clone());
+            spawn_local(async move {
+                if api::delete_project(&id).await.is_ok() {
+                    selected.set(String::new());
+                    if let Some(reload) = &reload {
+                        reload.emit(());
+                    }
+                }
+            });
+        })
+    };
+
+    html! {
+        <div class="settings-card settings-card--danger">
+            <h2 class="settings-card__title">{ "Danger zone" }</h2>
+            <p class="settings-card__desc">
+                { "Deleting a project removes its tracking pixels and unassigns its sources. Historical events are retained under those sources." }
+            </p>
+            <div class="form-row">
+                <Dropdown items={items} value={(*selected).clone()}
+                    placeholder="Select a project…" on_select={on_select} />
+                <button class="btn btn--danger" onclick={on_delete} disabled={(*selected).is_empty()}>
+                    { "Delete project" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/ui/src/pages/sources.rs
+++ b/ui/src/pages/sources.rs
@@ -1,70 +1,50 @@
-use analytics_api::{Project, Source, SourceInput, source_label};
+//! The per-project Sources tab: a summary of the sources assigned to this project,
+//! plus a "Manage sources" drawer for toggling membership.
+
+use analytics_api::{Source, SourceInput, SourceKind, source_label};
 use wasm_bindgen_futures::spawn_local;
-use web_sys::HtmlSelectElement;
 use yew::prelude::*;
 
 use crate::api::{self, ApiError};
-use crate::components::ApiErrorAlert;
+use crate::components::{ApiErrorAlert, Drawer};
 
-#[function_component(Sources)]
-pub fn sources() -> Html {
-    let projects = use_state(Vec::<Project>::new);
+/// A human label for a source kind (avoids leaking Rust `Debug` formatting).
+fn kind_label(kind: &SourceKind) -> &'static str {
+    match kind {
+        SourceKind::Website => "Website",
+        SourceKind::Application => "Application",
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct ProjectSourcesProps {
+    pub id: String,
+}
+
+#[function_component(ProjectSources)]
+pub fn project_sources(props: &ProjectSourcesProps) -> Html {
+    let id = props.id.clone();
     let sources = use_state(|| None::<Result<Vec<Source>, ApiError>>);
     let reload = use_state(|| 0u32);
+    let drawer_open = use_state(|| false);
 
     {
-        let (projects, sources) = (projects.clone(), sources.clone());
+        let sources = sources.clone();
         use_effect_with(*reload, move |_| {
             spawn_local(async move {
-                if let Ok(list) = api::list_projects().await {
-                    projects.set(list);
-                }
                 sources.set(Some(api::list_sources().await));
             });
             || ()
         });
     }
 
-    html! {
-        <div class="page">
-            <h1>{ "Sources" }</h1>
-            <p class="muted">{ "Group reporting hostnames into projects." }</p>
-            {
-                match &*sources {
-                    None => html! { <p class="muted">{ "Loading…" }</p> },
-                    Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
-                    Some(Ok(list)) if list.is_empty() => html! {
-                        <p class="muted">{ "No sources yet. They appear automatically once a site starts reporting." }</p>
-                    },
-                    Some(Ok(list)) => html! {
-                        <table class="list">
-                            <thead><tr><th>{ "Source" }</th><th>{ "Kind" }</th><th>{ "Project" }</th><th></th></tr></thead>
-                            <tbody>
-                            { for list.iter().map(|s| source_row(s, &projects, &reload)) }
-                            </tbody>
-                        </table>
-                    },
-                }
-            }
-        </div>
-    }
-}
-
-fn source_row(source: &Source, projects: &[Project], reload: &UseStateHandle<u32>) -> Html {
-    let uri = source.uri.clone();
-    let current = source.project_id.clone().unwrap_or_default();
-
-    let on_assign = {
-        let (uri, reload) = (uri.clone(), reload.clone());
-        Callback::from(move |e: Event| {
-            let select: HtmlSelectElement = e.target_unchecked_into();
-            let project_id = select.value();
-            let input = SourceInput {
-                project_id: Some(project_id),
-                ..Default::default()
-            };
-            let (uri, reload) = (uri.clone(), reload.clone());
+    // Assign (`Some(project)`) or release (`Some("")`, which the server unassigns).
+    let set_project: Callback<(String, String)> = {
+        let reload = reload.clone();
+        Callback::from(move |(uri, project_id): (String, String)| {
+            let reload = reload.clone();
             spawn_local(async move {
+                let input = SourceInput { project_id: Some(project_id), ..Default::default() };
                 if api::update_source(&uri, &input).await.is_ok() {
                     reload.set(*reload + 1);
                 }
@@ -72,31 +52,84 @@ fn source_row(source: &Source, projects: &[Project], reload: &UseStateHandle<u32
         })
     };
 
-    let on_delete = {
-        let (uri, reload) = (uri.clone(), reload.clone());
-        Callback::from(move |_| {
-            let (uri, reload) = (uri.clone(), reload.clone());
-            spawn_local(async move {
-                if api::delete_source(&uri).await.is_ok() {
-                    reload.set(*reload + 1);
-                }
-            });
-        })
+    let open_drawer = {
+        let drawer_open = drawer_open.clone();
+        Callback::from(move |_| drawer_open.set(true))
+    };
+    let close_drawer = {
+        let drawer_open = drawer_open.clone();
+        Callback::from(move |_| drawer_open.set(false))
     };
 
-    html! {
-        <tr>
-            <td><code>{ source_label(&source.uri) }</code></td>
-            <td>{ format!("{:?}", source.kind).to_lowercase() }</td>
-            <td>
-                <select class="input" onchange={on_assign}>
-                    <option value="" selected={current.is_empty()}>{ "Unassigned" }</option>
-                    { for projects.iter().map(|p| html! {
-                        <option value={p.id.clone()} selected={p.id == current}>{ &p.name }</option>
-                    }) }
-                </select>
-            </td>
-            <td><button class="btn btn--ghost" onclick={on_delete}>{ "Delete" }</button></td>
-        </tr>
+    match &*sources {
+        None => html! { <p class="muted">{ "Loading…" }</p> },
+        Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
+        Some(Ok(list)) => {
+            let mine: Vec<&Source> =
+                list.iter().filter(|s| s.project_id.as_deref() == Some(id.as_str())).collect();
+
+            let assigned = if mine.is_empty() {
+                html! { <div class="empty">{ "No sources assigned to this project yet." }</div> }
+            } else {
+                html! {
+                    <div class="card-table">
+                        <table class="list">
+                            <thead><tr><th>{ "Source" }</th><th>{ "Kind" }</th></tr></thead>
+                            <tbody>
+                                { for mine.iter().map(|s| html! {
+                                    <tr>
+                                        <td><code>{ source_label(&s.uri) }</code></td>
+                                        <td>{ kind_label(&s.kind) }</td>
+                                    </tr>
+                                }) }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            };
+
+            let rows = list.iter().map(|s| {
+                let member = s.project_id.as_deref() == Some(id.as_str());
+                let elsewhere = s.project_id.is_some() && !member;
+                let onclick = {
+                    let (set_project, uri, id) = (set_project.clone(), s.uri.clone(), id.clone());
+                    Callback::from(move |_| {
+                        let target = if member { String::new() } else { id.clone() };
+                        set_project.emit((uri.clone(), target));
+                    })
+                };
+                let (label, class) = if member {
+                    ("Remove", "btn btn--small btn--ghost")
+                } else {
+                    ("Add", "btn btn--small")
+                };
+                html! {
+                    <div class="toggle-row">
+                        <span class="toggle-row__label" title={s.uri.clone()}>{ source_label(&s.uri) }</span>
+                        if elsewhere {
+                            <span class="badge badge--muted">{ "Assigned elsewhere" }</span>
+                        }
+                        <button class={class} {onclick}>{ label }</button>
+                    </div>
+                }
+            }).collect::<Html>();
+
+            html! {
+                <>
+                    <div class="form-row">
+                        <button class="btn" onclick={open_drawer}>{ "Manage sources" }</button>
+                    </div>
+                    { assigned }
+                    <Drawer open={*drawer_open} title="Manage sources" on_close={close_drawer}>
+                        <p class="drawer__hint">{ "Toggle which reporting sources belong to this project." }</p>
+                        if list.is_empty() {
+                            <div class="empty">{ "No sources have reported yet." }</div>
+                        } else {
+                            { rows }
+                        }
+                    </Drawer>
+                </>
+            }
+        }
     }
 }

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -1,0 +1,147 @@
+//! The unified search filter shared by the app bar and the routed pages.
+//!
+//! A query is a space-separated list of terms. A term may be scoped to a property
+//! with a `field:value` prefix (for example `project:blog` or `status:resolved`);
+//! an unscoped term matches against every searchable property of a row. All terms
+//! must match (logical AND); matching is case-insensitive and substring-based.
+
+use std::rc::Rc;
+
+use yew::prelude::*;
+
+/// The canonical `field:` prefixes offered as autocomplete suggestions, paired
+/// with a short human description. The order here is the order presented.
+pub const FIELD_PREFIXES: &[(&str, &str)] = &[
+    ("project:", "Match a project by name"),
+    ("page:", "Match a page path"),
+    ("source:", "Match a reporting source"),
+    ("status:", "Match an exception status"),
+];
+
+/// A property a search term can be scoped to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Field {
+    Project,
+    Page,
+    Source,
+    Status,
+}
+
+impl Field {
+    fn parse(prefix: &str) -> Option<Field> {
+        match prefix.to_ascii_lowercase().as_str() {
+            "project" | "proj" | "p" => Some(Field::Project),
+            "page" | "path" => Some(Field::Page),
+            "source" | "src" | "host" => Some(Field::Source),
+            "status" | "state" => Some(Field::Status),
+            _ => None,
+        }
+    }
+}
+
+/// A single parsed search term.
+#[derive(Clone, PartialEq)]
+struct Term {
+    /// The property the term is scoped to, or `None` for free text.
+    field: Option<Field>,
+    /// The lowercased needle to look for.
+    needle: String,
+}
+
+/// A parsed query: a conjunction of [`Term`]s.
+#[derive(Clone, PartialEq, Default)]
+pub struct SearchFilter {
+    terms: Vec<Term>,
+}
+
+/// The searchable properties of a single row, supplied when evaluating a filter.
+/// A field a page doesn't have is left empty; `text` is a pre-lowercased blob of
+/// everything searchable, used for free-text terms.
+#[derive(Default)]
+pub struct MatchContext<'a> {
+    pub project: &'a str,
+    pub page: &'a str,
+    pub source: &'a str,
+    pub status: &'a str,
+    pub text: &'a str,
+}
+
+impl SearchFilter {
+    /// Parse a raw query string. A `field:value` token is only scoped when `field`
+    /// is a known property; otherwise the whole token is a free-text term.
+    pub fn parse(query: &str) -> Self {
+        let terms = query
+            .split_whitespace()
+            .filter_map(|token| {
+                if let Some((prefix, value)) = token.split_once(':')
+                    && let Some(field) = Field::parse(prefix)
+                {
+                    if value.is_empty() {
+                        return None;
+                    }
+                    return Some(Term {
+                        field: Some(field),
+                        needle: value.to_lowercase(),
+                    });
+                }
+                Some(Term {
+                    field: None,
+                    needle: token.to_lowercase(),
+                })
+            })
+            .collect();
+        Self { terms }
+    }
+
+    /// Evaluate the filter against a single row.
+    pub fn matches(&self, ctx: &MatchContext) -> bool {
+        self.terms.iter().all(|term| {
+            let haystack = match term.field {
+                Some(Field::Project) => ctx.project,
+                Some(Field::Page) => ctx.page,
+                Some(Field::Source) => ctx.source,
+                Some(Field::Status) => ctx.status,
+                None => ctx.text,
+            };
+            haystack.to_lowercase().contains(&term.needle)
+        })
+    }
+}
+
+/// Shared search state: the app bar owns the input, pages consume the parsed filter.
+#[derive(Clone, PartialEq)]
+pub struct SearchContext {
+    pub query: AttrValue,
+    pub filter: Rc<SearchFilter>,
+    pub set: Callback<String>,
+}
+
+/// Concrete values offered for context-aware completion of scoped terms. Project
+/// names come from the shell's project list; the page-specific lists (pages,
+/// sources, statuses) are published by the routed page that owns that data.
+#[derive(Clone, PartialEq, Default)]
+pub struct SearchVocabulary {
+    pub pages: Vec<AttrValue>,
+    pub sources: Vec<AttrValue>,
+    pub statuses: Vec<AttrValue>,
+}
+
+impl SearchVocabulary {
+    /// Candidate values for a page-published field, or `None` for `project:`
+    /// (which the app bar completes from the shell's project list instead).
+    pub fn values_for(&self, field: &str) -> Option<&[AttrValue]> {
+        match Field::parse(field)? {
+            Field::Page => Some(&self.pages),
+            Field::Source => Some(&self.sources),
+            Field::Status => Some(&self.statuses),
+            Field::Project => None,
+        }
+    }
+}
+
+/// The shared completion vocabulary, provided above both the app bar and the page.
+#[derive(Clone, PartialEq)]
+pub struct VocabularyContext {
+    pub vocabulary: Rc<SearchVocabulary>,
+    pub set: Callback<SearchVocabulary>,
+}

--- a/ui/src/styles/_base.scss
+++ b/ui/src/styles/_base.scss
@@ -1,0 +1,62 @@
+// Reset, document defaults, and global element styles.
+@use 'variables' as *;
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+a {
+  color: var(--brand);
+  text-decoration: none;
+  transition: color var(--transition);
+
+  &:hover {
+    color: var(--brand-2);
+  }
+}
+
+code,
+pre {
+  font-family: var(--font-mono);
+}
+
+.muted {
+  color: var(--text-3);
+}
+
+::selection {
+  background: var(--brand-soft);
+}
+
+// Slim, unobtrusive scrollbars.
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}

--- a/ui/src/styles/_layout.scss
+++ b/ui/src/styles/_layout.scss
@@ -1,0 +1,43 @@
+// Structural chrome: the signed-in shell (app bar row, sidebar + main columns,
+// content column, footer). Component-specific styling lives in its own partial.
+@use 'variables' as *;
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+// Two-column body: sidebar + main.
+.app-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  align-items: start;
+  min-height: 0;
+}
+
+.app-main {
+  min-width: 0;
+}
+
+.app-content {
+  max-width: var(--content-max);
+  padding: 1.75rem 2.25rem 4rem;
+}
+
+.app-footer {
+  padding: 1.5rem 2.25rem;
+  font-size: 0.78rem;
+  color: var(--text-3);
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: $bp-sm) {
+  .app-body {
+    grid-template-columns: 1fr;
+  }
+  .app-content {
+    padding: 1.25rem 1.25rem 3rem;
+  }
+}

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -1,0 +1,75 @@
+// Design tokens (CSS custom properties), shared SCSS mixins, and breakpoints.
+// Every other partial does `@use '../styles/variables' as *;` to reach the mixins
+// and breakpoints; the `:root` block below is emitted once into the bundle.
+
+:root {
+  // Canvas & surfaces (near-black, faintly blue; each step lifts toward light).
+  --bg: #0e1014;
+  --surface: #16181d;
+  --surface-2: #1b1e25;
+  --surface-3: #232730;
+  --overlay: #1b1e25;
+
+  // Hairlines.
+  --border: #262a32;
+  --border-strong: #333945;
+
+  // Text (descending emphasis).
+  --text: #e7e9ee;
+  --text-2: #b6bcc7;
+  --text-3: #888f9c;
+  --text-4: #5d6470;
+
+  // Brand — a Sierra Softworks teal. `--brand` is bright enough to read as text
+  // and icons on the dark canvas; `--brand-strong` is darkened so white text on a
+  // brand-filled surface (primary buttons, avatars) clears WCAG AA contrast.
+  --brand: #3da4dc;
+  --brand-2: #5cb8ea;
+  --brand-strong: #1c7aac;
+  --brand-strong-2: #2189bd;
+  --brand-soft: rgba(61, 164, 220, 0.14);
+  --brand-border: rgba(61, 164, 220, 0.38);
+
+  // Status.
+  --ok: #4ec07a;
+  --ok-soft: rgba(78, 192, 122, 0.14);
+  --warn: #e0a93c;
+  --warn-soft: rgba(224, 169, 60, 0.14);
+  --danger: #ed6a64;
+  --danger-soft: rgba(237, 106, 100, 0.14);
+  --info: #8b92a0;
+  --info-soft: rgba(139, 146, 160, 0.14);
+
+  // Shape, depth, motion.
+  --radius-sm: 5px;
+  --radius: 7px;
+  --radius-lg: 10px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 8px 28px rgba(0, 0, 0, 0.45);
+  --transition: 120ms ease;
+
+  // Metrics.
+  --sidebar-w: 248px;
+  --bar-h: 56px;
+  --content-max: 1180px;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+// Responsive breakpoints (SCSS, for media queries).
+$bp-md: 960px;
+$bp-sm: 820px;
+
+@mixin card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+@mixin focus-ring {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px var(--brand-soft);
+}

--- a/ui/styles.scss
+++ b/ui/styles.scss
@@ -1,131 +1,28 @@
-:root {
-  --bg: #0f1115;
-  --fg: #e6e8eb;
-  --muted: #9aa0a6;
-  --accent: #4c8bf5;
-  --panel: #181b21;
-  --panel2: #1f232b;
-  --border: #272b33;
-  --ok: #3fb950;
-  --warn: #d29922;
-  --err: #f85149;
-}
+// =============================================================================
+// Analytics dashboard stylesheet
+//
+// A dark, typography-centric theme: the Element Plus palette and component shapes
+// remapped onto a dark canvas, with the restrained colour and generous whitespace
+// of tools like Linear. The styles are decomposed into per-component partials (see
+// SierraSoftworks/grey): design tokens + foundation under `src/styles/`, one
+// partial per component/area under `src/components/`, all assembled here.
+// =============================================================================
 
-* { box-sizing: border-box; }
+// Foundation — tokens, reset, structural layout.
+@use 'src/styles/variables';
+@use 'src/styles/base';
+@use 'src/styles/layout';
 
-body {
-  margin: 0;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  background: var(--bg);
-  color: var(--fg);
-  font-size: 14px;
-}
-
-a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-.muted { color: var(--muted); }
-
-.topbar {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  padding: 0.75rem 1.5rem;
-  border-bottom: 1px solid var(--border);
-  background: var(--panel);
-}
-.topbar__brand { display: flex; align-items: baseline; gap: 0.5rem; }
-.brand { font-weight: 700; font-size: 1.1rem; color: var(--fg); }
-.brand__by { color: var(--muted); font-size: 0.8rem; }
-.topbar__nav { display: flex; gap: 1rem; }
-.topbar__nav a { color: var(--muted); }
-.topbar__nav a:hover { color: var(--fg); text-decoration: none; }
-.topbar__user { margin-left: auto; display: flex; align-items: center; gap: 0.75rem; }
-
-.content { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
-.page h1 { font-size: 1.5rem; margin: 0 0 1rem; }
-.page h2 { font-size: 1.1rem; margin: 1.75rem 0 0.75rem; }
-.crumb { margin: 0 0 0.5rem; }
-.centered { text-align: center; padding: 4rem 1rem; }
-
-.cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; }
-.card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem;
-}
-.card__value { font-size: 1.75rem; font-weight: 700; }
-.card__label { color: var(--muted); margin-top: 0.25rem; }
-
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem;
-  margin-top: 1rem;
-}
-.chart { width: 100%; height: 160px; display: block; }
-.chart .bar { fill: var(--accent); opacity: 0.85; }
-.chart .bar:hover { opacity: 1; }
-
-.breakdowns { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin-top: 1rem; }
-.breakdown {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem;
-}
-.breakdown h3 { margin: 0 0 0.5rem; font-size: 0.95rem; }
-.breakdown table { width: 100%; border-collapse: collapse; }
-.breakdown td { padding: 0.2rem 0; border-bottom: 1px solid var(--border); }
-.breakdown__key { max-width: 0; width: 80%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.breakdown__count { text-align: right; color: var(--muted); }
-
-.list { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
-.list th { text-align: left; color: var(--muted); font-weight: 500; padding: 0.4rem 0.5rem; border-bottom: 1px solid var(--border); }
-.list td { padding: 0.5rem; border-bottom: 1px solid var(--border); }
-.ellipsis { max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-
-.tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid var(--border); margin: 1rem 0; }
-.tab {
-  background: none; border: none; color: var(--muted);
-  padding: 0.5rem 0.9rem; cursor: pointer; border-bottom: 2px solid transparent;
-}
-.tab--active { color: var(--fg); border-bottom-color: var(--accent); }
-
-.btn {
-  background: var(--panel2); color: var(--fg);
-  border: 1px solid var(--border); border-radius: 6px;
-  padding: 0.4rem 0.8rem; cursor: pointer; font-size: 0.85rem;
-}
-.btn:hover { border-color: var(--accent); }
-.btn--primary { background: var(--accent); border-color: var(--accent); color: white; }
-.btn--ghost { background: none; }
-
-.input {
-  background: var(--panel2); color: var(--fg);
-  border: 1px solid var(--border); border-radius: 6px;
-  padding: 0.4rem 0.6rem; font-size: 0.85rem;
-}
-.form-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
-
-.alert { padding: 0.75rem 1rem; border-radius: 6px; border: 1px solid var(--border); }
-.alert--error { border-color: var(--err); color: var(--err); background: rgba(248, 81, 73, 0.08); }
-
-.badge { padding: 0.1rem 0.5rem; border-radius: 999px; font-size: 0.75rem; }
-.badge--ok { background: rgba(63, 185, 80, 0.15); color: var(--ok); }
-.badge--warn { background: rgba(210, 153, 34, 0.15); color: var(--warn); }
-.badge--muted { background: var(--panel2); color: var(--muted); }
-
-.embed { font-size: 0.75rem; color: var(--muted); word-break: break-all; }
-
-.exc-header { display: flex; align-items: center; gap: 0.75rem; }
-.exc-message { font-family: ui-monospace, monospace; color: var(--fg); }
-.occurrence { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 0.75rem; }
-.occurrence__meta { font-size: 0.8rem; margin-bottom: 0.25rem; }
-.stack { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem; overflow-x: auto; font-size: 0.8rem; white-space: pre-wrap; }
-
-@media (max-width: 720px) {
-  .cards { grid-template-columns: repeat(2, 1fr); }
-  .breakdowns { grid-template-columns: 1fr; }
-}
+// Components & page areas.
+@use 'src/components/controls';
+@use 'src/components/alert';
+@use 'src/components/app_bar';
+@use 'src/components/sidebar';
+@use 'src/components/page_header';
+@use 'src/components/stats';
+@use 'src/components/tables';
+@use 'src/components/drawer';
+@use 'src/components/dropdown';
+@use 'src/components/settings';
+@use 'src/components/exceptions';
+@use 'src/components/auth';


### PR DESCRIPTION
## Summary

A ground-up redesign of the analytics dashboard — a dark, typography-centric theme
built on Element Plus design tokens with the restraint and layout of Linear.app —
plus the backend endpoints it needs, a new global Exceptions inbox, and a modular
stylesheet. Two commits: backend, then frontend.

## Backend

- **`GET /api/v1/instance`** (authenticated) — running version + operational posture
  (retention, hot window, DNT, rate limits). The public `/health` still reveals
  nothing.
- **`GET /api/v1/pixels`** — all pixels across projects (for the global Pixels page).
- **`GET /api/v1/exceptions`** — a global exception inbox. Grouped by
  `(fingerprint, source)` then folded up per project, so an error whose fingerprint
  is shared across projects is **never** collapsed into, or misattributed to, a
  single project (each project's count matches its detail page).
- **Atomic project-delete cascade** — unassign sources + delete pixels + delete the
  project in one redb write transaction, so a partial failure can't half-delete a
  project.
- **Time-series zero-fill** — empty buckets are filled across the window for gap-free
  charts; new **6-hour** and **weekly** bucket intervals.
- Telemetry handles the now-must-use `set_parent` result; the example-config test
  tolerates a tuned sample port.
- Restores a clean **`Cargo.lock`** — the committed lockfile had duplicated package
  entries (inflated to 546 packages with three conflicting `brotli` versions) and
  failed to parse.

## Frontend

- **Chrome** — persistent app bar (Sierra Softworks brand, centred contextual search
  with `field:value` autocomplete that jumps to any project, OIDC user chip) and a
  left sidebar (Overview · Exceptions · Projects · Tracking pixels · Settings).
- **Pages** — redesigned Overview, Project (Statistics / Sources / Exceptions tabs),
  global Tracking Pixels, Settings (account, instance info incl. auth-only version,
  copyable tracker snippet, danger zone), a global Exceptions inbox, and restyled
  exception detail + sign-in / 404.
- **Wizards in a drawer** — a reusable slide-in `Drawer` for new project (with source
  assignment + name defaulting to the first source), pixel create/edit with a
  key/value metadata editor, and source membership.
- **Cohesive controls** — a custom themed `Dropdown` replaces every native
  `<select>` (fixed-positioned so it is never clipped inside a drawer); a header
  lookback picker (24h hourly · 7d in 6h · 30d/90d daily · a year weekly) drives the
  stats.
- **Recoverability** — a mid-session `401` returns to sign-in; an OIDC-disabled
  instance no longer loops on sign-in.

## Stylesheet

Decomposed the monolithic `ui/styles.scss` into per-component partials —
`src/styles/_{variables,base,layout}.scss` (foundation) and
`src/components/_*.scss` (one per component/area) — assembled with `@use`, mirroring
[SierraSoftworks/grey](https://github.com/SierraSoftworks/grey/blob/main/ui/styles.scss).

## Verification

- `cargo test` (48 agent + 2 api), `cargo clippy` clean across the workspace and the
  `wasm32` UI; `trunk build --release` clean.
- Every page and flow was exercised live in the browser preview (drawers, dropdowns,
  lookback, the global Exceptions inbox, the create-project source picker) with an
  error-free console.
- Each batch went through an adversarial multi-agent review; all confirmed findings
  were fixed (notably the cross-project exception grouping above), with regression
  tests added.

## Notes for reviewers

- Adds `.claude/launch.json` so the local preview harness can serve the app.
- `ui/target/` is gitignored (not part of this PR).
- Pushed over HTTPS because the local SSH agent was unavailable; line-ending
  warnings during commit are Git's normal LF→CRLF notices on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
