### PR TITLE
ci: fix rust cache for cross (arm64) build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,6 +215,16 @@ jobs:
       - name: cargo build
         run: ${{ matrix.builder }} build --release --target ${{ matrix.target }}
 
+      # cross runs the compiler inside a Docker container as root, so the
+      # registry downloads and build artifacts it writes into the cached
+      # directories end up owned by root. Swatinem/rust-cache's save step runs
+      # as the unprivileged runner user and cannot prune root-owned files,
+      # which causes the cache save to fail and the cross build to never be
+      # cached. Reclaim ownership so the cache can be persisted.
+      - name: Reclaim cache ownership from cross
+        if: matrix.builder == 'cross'
+        run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
+
       - name: Upload GitHub Release Artifacts
         uses: SierraSoftworks/gh-releases@v1.0.9
         if: github.event_name == 'release'


### PR DESCRIPTION
## Problem

The `cross`-built (linux-arm64) target in `rust.yml` never benefits from `Swatinem/rust-cache` — every run starts cold and recompiles from scratch.

## Root cause

`cross` compiles inside a Docker container running as **root**. It bind-mounts the host cargo registry (`~/.cargo`) and writes artifacts into `./target` — exactly the paths `rust-cache` caches — so every file it writes ends up owned by `root:root`. `rust-cache`'s post-job **save** step runs as the unprivileged `runner` user and can't prune root-owned files, so the save fails and no cache is ever stored for the cross target. The plain `cargo` builders run as the runner directly, so they're unaffected.

## Fix

After the build, reclaim ownership of the cached paths so `rust-cache`'s save step can prune and persist them:

```yaml
- name: Reclaim cache ownership from cross
  if: matrix.builder == 'cross'
  run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
```

Gated to `matrix.builder == 'cross'` so it only runs where needed.

Ports the fix from SierraSoftworks/automate#197 to this repository.

https://claude.ai/code/session_01MsS7yTeVW686QKQcTa3HgW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsS7yTeVW686QKQcTa3HgW)_