### PR TITLE
Fix the Nix flake build and update crane to its latest release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,11 +180,6 @@ jobs:
           target: ${{ matrix.target }}
           components: llvm-tools-preview
 
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
-
       - name: Check out code
         uses: actions/checkout@v6
 
@@ -211,6 +206,14 @@ jobs:
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cross
+
+      # Set up the cache only after all tooling (e.g. cross) is installed, and
+      # after checkout so it can key on Cargo.lock. Restoring it before the
+      # tools were installed left cross off the PATH for the build.
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: cargo build
         run: ${{ matrix.builder }} build --release --target ${{ matrix.target }}

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -102,8 +102,7 @@ pub fn overview(
     let mut project_summaries: Vec<ProjectSummary> = projects
         .into_iter()
         .map(|project| {
-            let (visitors, pageviews) =
-                project_totals.get(&project.id).copied().unwrap_or((0, 0));
+            let (visitors, pageviews) = project_totals.get(&project.id).copied().unwrap_or((0, 0));
             ProjectSummary {
                 project,
                 visitors,
@@ -155,22 +154,55 @@ pub fn exception_groups(
         .group_by([col("exc_group")])
         .agg([
             len().cast(DataType::Int64).alias("count"),
-            col("received_ms").min().cast(DataType::Int64).alias("first_seen"),
-            col("received_ms").max().cast(DataType::Int64).alias("last_seen"),
+            col("received_ms")
+                .min()
+                .cast(DataType::Int64)
+                .alias("first_seen"),
+            col("received_ms")
+                .max()
+                .cast(DataType::Int64)
+                .alias("last_seen"),
             col("exc_type").first().alias("exc_type"),
             col("exc_message").first().alias("sample_message"),
         ])
-        .sort(["last_seen"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["last_seen"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .limit(200)
         .collect()
         .or_system_err(ADVICE)?;
 
-    let group_id = df.column("exc_group").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let count = df.column("count").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let first = df.column("first_seen").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let last = df.column("last_seen").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let exc_type = df.column("exc_type").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let message = df.column("sample_message").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+    let group_id = df
+        .column("exc_group")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let count = df
+        .column("count")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let first = df
+        .column("first_seen")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let last = df
+        .column("last_seen")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let exc_type = df
+        .column("exc_type")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let message = df
+        .column("sample_message")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
 
     Ok((0..df.height())
         .filter_map(|i| {
@@ -205,23 +237,60 @@ pub fn global_exception_groups(
         .group_by([col("exc_group"), col("source")])
         .agg([
             len().cast(DataType::Int64).alias("count"),
-            col("received_ms").min().cast(DataType::Int64).alias("first_seen"),
-            col("received_ms").max().cast(DataType::Int64).alias("last_seen"),
+            col("received_ms")
+                .min()
+                .cast(DataType::Int64)
+                .alias("first_seen"),
+            col("received_ms")
+                .max()
+                .cast(DataType::Int64)
+                .alias("last_seen"),
             col("exc_type").first().alias("exc_type"),
             col("exc_message").first().alias("sample_message"),
         ])
-        .sort(["last_seen"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["last_seen"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .limit(500)
         .collect()
         .or_system_err(ADVICE)?;
 
-    let group_id = df.column("exc_group").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let count = df.column("count").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let first = df.column("first_seen").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let last = df.column("last_seen").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let exc_type = df.column("exc_type").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let message = df.column("sample_message").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let source = df.column("source").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+    let group_id = df
+        .column("exc_group")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let count = df
+        .column("count")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let first = df
+        .column("first_seen")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let last = df
+        .column("last_seen")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let exc_type = df
+        .column("exc_type")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let message = df
+        .column("sample_message")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let source = df
+        .column("source")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
 
     Ok((0..df.height())
         .filter_map(|i| {
@@ -266,11 +335,16 @@ pub fn exception_detail(
             col("exc_message"),
             col("exc_stack"),
             col("exc_handled"),
-            col("received_ms").cast(DataType::Int64).alias("received_ms"),
+            col("received_ms")
+                .cast(DataType::Int64)
+                .alias("received_ms"),
             col("ua_browser"),
             col("ua_os"),
         ])
-        .sort(["received_ms"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["received_ms"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .collect()
         .or_system_err(ADVICE)?;
 
@@ -279,13 +353,41 @@ pub fn exception_detail(
         return Ok(None);
     }
 
-    let exc_type = df.column("exc_type").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let message = df.column("exc_message").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let stack = df.column("exc_stack").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let handled = df.column("exc_handled").or_system_err(ADVICE)?.bool().or_system_err(ADVICE)?;
-    let received = df.column("received_ms").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let browser = df.column("ua_browser").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let os = df.column("ua_os").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
+    let exc_type = df
+        .column("exc_type")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let message = df
+        .column("exc_message")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let stack = df
+        .column("exc_stack")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let handled = df
+        .column("exc_handled")
+        .or_system_err(ADVICE)?
+        .bool()
+        .or_system_err(ADVICE)?;
+    let received = df
+        .column("received_ms")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let browser = df
+        .column("ua_browser")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let os = df
+        .column("ua_os")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
 
     // Rows are newest-first: index 0 is the most recent occurrence, the last index the
     // oldest. The aggregate spans every row; the returned occurrences keep `limit`.
@@ -416,7 +518,12 @@ fn summary(base: LazyFrame) -> Result<MetricSummary> {
 /// A continuous time series over `[from_ms, to_ms]` at `bucket_ms` resolution.
 /// Buckets with no events are emitted as zeros so the chart shows a gap-free line
 /// across the whole window instead of collapsing absent periods.
-fn timeseries(base: LazyFrame, from_ms: i64, to_ms: i64, bucket_ms: i64) -> Result<Vec<TimeSeriesPoint>> {
+fn timeseries(
+    base: LazyFrame,
+    from_ms: i64,
+    to_ms: i64,
+    bucket_ms: i64,
+) -> Result<Vec<TimeSeriesPoint>> {
     let bucket_ms = bucket_ms.max(1);
     let df = base
         .filter(col("kind").eq(lit("page_load")))
@@ -432,15 +539,30 @@ fn timeseries(base: LazyFrame, from_ms: i64, to_ms: i64, bucket_ms: i64) -> Resu
         .collect()
         .or_system_err(ADVICE)?;
 
-    let bucket = df.column("bucket").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let pageviews = df.column("pageviews").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let visitors = df.column("visitors").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
+    let bucket = df
+        .column("bucket")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let pageviews = df
+        .column("pageviews")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let visitors = df
+        .column("visitors")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
 
     // Index the populated buckets, then walk every bucket in the window.
     let mut counts: std::collections::HashMap<i64, (i64, i64)> = std::collections::HashMap::new();
     for i in 0..df.height() {
         if let Some(b) = bucket.get(i) {
-            counts.insert(b, (pageviews.get(i).unwrap_or(0), visitors.get(i).unwrap_or(0)));
+            counts.insert(
+                b,
+                (pageviews.get(i).unwrap_or(0), visitors.get(i).unwrap_or(0)),
+            );
         }
     }
 
@@ -452,7 +574,11 @@ fn timeseries(base: LazyFrame, from_ms: i64, to_ms: i64, bucket_ms: i64) -> Resu
         // Fall back to the populated buckets only (sorted).
         let mut points: Vec<TimeSeriesPoint> = counts
             .into_iter()
-            .map(|(b, (p, v))| TimeSeriesPoint { timestamp_ms: b, pageviews: p, visitors: v })
+            .map(|(b, (p, v))| TimeSeriesPoint {
+                timestamp_ms: b,
+                pageviews: p,
+                visitors: v,
+            })
             .collect();
         points.sort_by_key(|p| p.timestamp_ms);
         return Ok(points);
@@ -462,7 +588,11 @@ fn timeseries(base: LazyFrame, from_ms: i64, to_ms: i64, bucket_ms: i64) -> Resu
     let mut b = first;
     while b <= last {
         let (pageviews, visitors) = counts.get(&b).copied().unwrap_or((0, 0));
-        points.push(TimeSeriesPoint { timestamp_ms: b, pageviews, visitors });
+        points.push(TimeSeriesPoint {
+            timestamp_ms: b,
+            pageviews,
+            visitors,
+        });
         b += bucket_ms;
     }
     Ok(points)
@@ -473,13 +603,24 @@ fn breakdown(pageloads: LazyFrame, column: &str) -> Result<Vec<KeyCount>> {
         .filter(col(column).is_not_null())
         .group_by([col(column)])
         .agg([len().cast(DataType::Int64).alias("count")])
-        .sort(["count"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["count"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .limit(BREAKDOWN_LIMIT)
         .collect()
         .or_system_err(ADVICE)?;
 
-    let keys = df.column(column).or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let counts = df.column("count").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
+    let keys = df
+        .column(column)
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let counts = df
+        .column("count")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
 
     Ok((0..df.height())
         .filter_map(|i| {
@@ -513,9 +654,21 @@ fn per_source_totals(base: LazyFrame) -> Result<Vec<(String, i64, i64)>> {
         .collect()
         .or_system_err(ADVICE)?;
 
-    let sources = df.column("source").or_system_err(ADVICE)?.str().or_system_err(ADVICE)?;
-    let pageviews = df.column("pageviews").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
-    let visitors = df.column("visitors").or_system_err(ADVICE)?.i64().or_system_err(ADVICE)?;
+    let sources = df
+        .column("source")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let pageviews = df
+        .column("pageviews")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let visitors = df
+        .column("visitors")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
 
     Ok((0..df.height())
         .filter_map(|i| {
@@ -680,7 +833,11 @@ mod tests {
         // Buckets at 0, 1d, 2d, 3d — empty days filled with zeros, not dropped.
         assert_eq!(stats.timeseries.len(), 4);
         assert_eq!(stats.timeseries[0].pageviews, 2);
-        assert!(stats.timeseries[1..].iter().all(|p| p.pageviews == 0 && p.visitors == 0));
+        assert!(
+            stats.timeseries[1..]
+                .iter()
+                .all(|p| p.pageviews == 0 && p.visitors == 0)
+        );
 
         drop(store);
         let _ = std::fs::remove_file(&redb);
@@ -788,7 +945,9 @@ mod tests {
     fn exception_group_lookup_ignores_the_recency_cap() {
         let redb = temp_redb();
         let store = Store::open(&redb).unwrap();
-        let events: Vec<_> = (1..=205).map(|i| exc(&format!("g{i}"), i * 1_000)).collect();
+        let events: Vec<_> = (1..=205)
+            .map(|i| exc(&format!("g{i}"), i * 1_000))
+            .collect();
         store.append_events(&events).unwrap();
         let sources = ["https://a.com".to_string()];
 

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -223,7 +223,10 @@ impl Config {
         }
 
         let raw = std::fs::read_to_string(path).wrap_user_err(
-            format!("Could not read the configuration file `{}`.", path.display()),
+            format!(
+                "Could not read the configuration file `{}`.",
+                path.display()
+            ),
             &["Check that the path is correct and that the file is readable."],
         )?;
         Self::from_yaml_str(&raw)
@@ -334,7 +337,10 @@ mod tests {
         let config =
             Config::from_yaml_str("telemetry:\n  sentry_dsn: ${{ env.ANALYTICS_TEST_DSN }}\n")
                 .unwrap();
-        assert_eq!(config.telemetry.sentry_dsn.as_deref(), Some("https://example/dsn"));
+        assert_eq!(
+            config.telemetry.sentry_dsn.as_deref(),
+            Some("https://example/dsn")
+        );
     }
 
     #[test]
@@ -360,7 +366,10 @@ mod tests {
         let config =
             Config::from_yaml_str("storage:\n  hot_window: 12h\n  retention: 30d\n").unwrap();
         assert_eq!(config.storage.hot_window, Duration::from_secs(12 * 3600));
-        assert_eq!(config.storage.retention, Duration::from_secs(30 * 24 * 3600));
+        assert_eq!(
+            config.storage.retention,
+            Duration::from_secs(30 * 24 * 3600)
+        );
     }
 
     #[test]

--- a/agent/src/ingest/compactor.rs
+++ b/agent/src/ingest/compactor.rs
@@ -134,7 +134,12 @@ mod tests {
     fn temp(suffix: &str) -> std::path::PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-        std::env::temp_dir().join(format!("analytics-compact-{}-{}-{}", std::process::id(), n, suffix))
+        std::env::temp_dir().join(format!(
+            "analytics-compact-{}-{}-{}",
+            std::process::id(),
+            n,
+            suffix
+        ))
     }
 
     fn event(received_ms: i64) -> StoredEvent {

--- a/agent/src/ingest/geo.rs
+++ b/agent/src/ingest/geo.rs
@@ -7,9 +7,17 @@
 pub fn country_from_timezone(tz: &str) -> Option<&'static str> {
     let code = match tz {
         // North America
-        "America/New_York" | "America/Detroit" | "America/Chicago" | "America/Denver"
-        | "America/Phoenix" | "America/Los_Angeles" | "America/Anchorage" | "America/Adak"
-        | "Pacific/Honolulu" | "America/Boise" | "America/Indiana/Indianapolis"
+        "America/New_York"
+        | "America/Detroit"
+        | "America/Chicago"
+        | "America/Denver"
+        | "America/Phoenix"
+        | "America/Los_Angeles"
+        | "America/Anchorage"
+        | "America/Adak"
+        | "Pacific/Honolulu"
+        | "America/Boise"
+        | "America/Indiana/Indianapolis"
         | "America/Kentucky/Louisville" => "US",
         "America/Toronto" | "America/Vancouver" | "America/Edmonton" | "America/Winnipeg"
         | "America/Halifax" | "America/St_Johns" | "America/Regina" => "CA",
@@ -111,8 +119,13 @@ pub fn country_from_timezone(tz: &str) -> Option<&'static str> {
         "Asia/Tokyo" => "JP",
         "Asia/Seoul" => "KR",
         // Oceania
-        "Australia/Sydney" | "Australia/Melbourne" | "Australia/Brisbane" | "Australia/Perth"
-        | "Australia/Adelaide" | "Australia/Hobart" | "Australia/Darwin" => "AU",
+        "Australia/Sydney"
+        | "Australia/Melbourne"
+        | "Australia/Brisbane"
+        | "Australia/Perth"
+        | "Australia/Adelaide"
+        | "Australia/Hobart"
+        | "Australia/Darwin" => "AU",
         "Pacific/Auckland" => "NZ",
         "Pacific/Fiji" => "FJ",
         _ => return None,

--- a/agent/src/ingest/language.rs
+++ b/agent/src/ingest/language.rs
@@ -19,7 +19,10 @@ mod tests {
 
     #[test]
     fn extracts_primary_language() {
-        assert_eq!(primary_language("en-US,en;q=0.9,fr;q=0.8").as_deref(), Some("en"));
+        assert_eq!(
+            primary_language("en-US,en;q=0.9,fr;q=0.8").as_deref(),
+            Some("en")
+        );
         assert_eq!(primary_language("de").as_deref(), Some("de"));
         assert_eq!(primary_language("*").as_deref(), None);
         assert_eq!(primary_language("").as_deref(), None);

--- a/agent/src/ingest/pipeline.rs
+++ b/agent/src/ingest/pipeline.rs
@@ -42,11 +42,7 @@ pub fn spawn(store: Arc<Store>, storage: StorageConfig) -> Ingest {
     Ingest { tx }
 }
 
-async fn writer_loop(
-    store: Arc<Store>,
-    mut rx: mpsc::Receiver<StoredEvent>,
-    max_sources: usize,
-) {
+async fn writer_loop(store: Arc<Store>, mut rx: mpsc::Receiver<StoredEvent>, max_sources: usize) {
     // Track already-registered sources in memory to avoid a store hit per event;
     // seed it once from the persisted sources.
     let mut known_sources: HashSet<String> = {

--- a/agent/src/ingest/referrer.rs
+++ b/agent/src/ingest/referrer.rs
@@ -10,12 +10,33 @@ pub struct Referrer {
 }
 
 const SEARCH: &[&str] = &[
-    "google.", "bing.", "duckduckgo.", "yahoo.", "yandex.", "baidu.", "ecosia.", "brave.",
-    "startpage.", "qwant.",
+    "google.",
+    "bing.",
+    "duckduckgo.",
+    "yahoo.",
+    "yandex.",
+    "baidu.",
+    "ecosia.",
+    "brave.",
+    "startpage.",
+    "qwant.",
 ];
 const SOCIAL: &[&str] = &[
-    "facebook.", "twitter.", "x.com", "t.co", "linkedin.", "reddit.", "instagram.", "youtube.",
-    "mastodon", "bsky.", "pinterest.", "tiktok.", "news.ycombinator.com", "lobste.rs", "threads.",
+    "facebook.",
+    "twitter.",
+    "x.com",
+    "t.co",
+    "linkedin.",
+    "reddit.",
+    "instagram.",
+    "youtube.",
+    "mastodon",
+    "bsky.",
+    "pinterest.",
+    "tiktok.",
+    "news.ycombinator.com",
+    "lobste.rs",
+    "threads.",
 ];
 
 /// Resolve a referrer URL to a host + group, treating same-host referrals as
@@ -25,7 +46,10 @@ pub fn classify(referrer: Option<&str>, self_host: &str) -> Referrer {
         return Referrer::default();
     };
 
-    let host = match Url::parse(raw).ok().and_then(|u| u.host_str().map(normalize)) {
+    let host = match Url::parse(raw)
+        .ok()
+        .and_then(|u| u.host_str().map(normalize))
+    {
         Some(h) => h,
         None => return Referrer::default(),
     };
@@ -69,7 +93,9 @@ mod tests {
             }
         );
         assert_eq!(
-            classify(Some("https://t.co/abc"), "example.com").group.as_deref(),
+            classify(Some("https://t.co/abc"), "example.com")
+                .group
+                .as_deref(),
             Some("Social")
         );
     }

--- a/agent/src/ratelimit.rs
+++ b/agent/src/ratelimit.rs
@@ -81,7 +81,10 @@ mod tests {
         let limiter = RateLimiter::new(60, 2);
         assert!(limiter.check("1.2.3.4"));
         assert!(limiter.check("1.2.3.4"));
-        assert!(!limiter.check("1.2.3.4"), "third immediate request is throttled");
+        assert!(
+            !limiter.check("1.2.3.4"),
+            "third immediate request is throttled"
+        );
         // A different key has its own bucket.
         assert!(limiter.check("5.6.7.8"));
     }

--- a/agent/src/store/entities.rs
+++ b/agent/src/store/entities.rs
@@ -56,7 +56,9 @@ impl Store {
                     }
                 }
                 for (key, bytes) in updates {
-                    sources.insert(key.as_str(), bytes.as_slice()).or_system_err(STORAGE_ADVICE)?;
+                    sources
+                        .insert(key.as_str(), bytes.as_slice())
+                        .or_system_err(STORAGE_ADVICE)?;
                 }
             }
             // Delete every pixel belonging to this project.
@@ -96,11 +98,7 @@ impl Store {
 
     /// Apply `f` to an existing source and persist it in one write transaction.
     /// Returns the updated source, or `None` if the URI is unknown.
-    pub fn mutate_source<F: FnOnce(&mut Source)>(
-        &self,
-        uri: &str,
-        f: F,
-    ) -> Result<Option<Source>> {
+    pub fn mutate_source<F: FnOnce(&mut Source)>(&self, uri: &str, f: F) -> Result<Option<Source>> {
         self.mutate_json(SOURCES, uri, f)
     }
 
@@ -146,11 +144,7 @@ impl Store {
     ) -> Result<()> {
         self.put_json(EXCEPTION_TRIAGE, &triage_key(project_id, group_id), triage)
     }
-    pub fn get_triage(
-        &self,
-        project_id: &str,
-        group_id: &str,
-    ) -> Result<Option<ExceptionTriage>> {
+    pub fn get_triage(&self, project_id: &str, group_id: &str) -> Result<Option<ExceptionTriage>> {
         self.get_json(EXCEPTION_TRIAGE, &triage_key(project_id, group_id))
     }
 }

--- a/agent/src/store/mod.rs
+++ b/agent/src/store/mod.rs
@@ -54,20 +54,27 @@ impl Store {
 /// Touch every table so it exists for later read transactions.
 fn ensure_tables(db: &Database) -> Result<()> {
     let txn = db.begin_write().or_system_err(tables::OPEN_ADVICE)?;
-    txn.open_table(tables::EVENTS).or_system_err(tables::OPEN_ADVICE)?;
-    txn.open_table(tables::PROJECTS).or_system_err(tables::OPEN_ADVICE)?;
-    txn.open_table(tables::SOURCES).or_system_err(tables::OPEN_ADVICE)?;
-    txn.open_table(tables::PIXELS).or_system_err(tables::OPEN_ADVICE)?;
+    txn.open_table(tables::EVENTS)
+        .or_system_err(tables::OPEN_ADVICE)?;
+    txn.open_table(tables::PROJECTS)
+        .or_system_err(tables::OPEN_ADVICE)?;
+    txn.open_table(tables::SOURCES)
+        .or_system_err(tables::OPEN_ADVICE)?;
+    txn.open_table(tables::PIXELS)
+        .or_system_err(tables::OPEN_ADVICE)?;
     txn.open_table(tables::EXCEPTION_TRIAGE)
         .or_system_err(tables::OPEN_ADVICE)?;
-    txn.open_table(tables::META).or_system_err(tables::OPEN_ADVICE)?;
+    txn.open_table(tables::META)
+        .or_system_err(tables::OPEN_ADVICE)?;
     txn.commit().or_system_err(tables::OPEN_ADVICE)?;
     Ok(())
 }
 
 fn read_next_seq(db: &Database) -> Result<u64> {
     let txn = db.begin_read().or_system_err(tables::OPEN_ADVICE)?;
-    let table = txn.open_table(tables::META).or_system_err(tables::OPEN_ADVICE)?;
+    let table = txn
+        .open_table(tables::META)
+        .or_system_err(tables::OPEN_ADVICE)?;
     match table
         .get(tables::META_NEXT_SEQ)
         .or_system_err(tables::STORAGE_ADVICE)?
@@ -166,7 +173,9 @@ mod tests {
         store
             .append_events(&[event("https://a.com", 1000), event("https://b.com", 2000)])
             .unwrap();
-        store.append_events(&[event("https://a.com", 3000)]).unwrap();
+        store
+            .append_events(&[event("https://a.com", 3000)])
+            .unwrap();
         assert_eq!(store.event_count().unwrap(), 3);
         let all = store.all_events().unwrap();
         assert_eq!(all.len(), 3);
@@ -176,12 +185,14 @@ mod tests {
 
     #[test]
     fn sequence_is_monotonic_across_reopen() {
-        let path = std::env::temp_dir()
-            .join(format!("analytics-test-{}-reopen.redb", std::process::id()));
+        let path =
+            std::env::temp_dir().join(format!("analytics-test-{}-reopen.redb", std::process::id()));
         let _ = std::fs::remove_file(&path);
         {
             let store = Store::open(&path).unwrap();
-            store.append_events(&[event("https://a.com", 1000)]).unwrap();
+            store
+                .append_events(&[event("https://a.com", 1000)])
+                .unwrap();
         }
         let reopened = Store::open(&path).unwrap();
         assert!(reopened.next_seq.load(Ordering::SeqCst) >= 1);
@@ -221,7 +232,12 @@ mod tests {
             .unwrap();
         assert_eq!(updated.unwrap().project_id.as_deref(), Some("p1"));
         assert_eq!(
-            store.get_source("https://a.com").unwrap().unwrap().project_id.as_deref(),
+            store
+                .get_source("https://a.com")
+                .unwrap()
+                .unwrap()
+                .project_id
+                .as_deref(),
             Some("p1")
         );
 
@@ -271,7 +287,14 @@ mod tests {
 
         assert!(store.delete_project_cascade("p1").unwrap());
         assert!(store.get_project("p1").unwrap().is_none());
-        assert_eq!(store.get_source("https://a.com").unwrap().unwrap().project_id, None);
+        assert_eq!(
+            store
+                .get_source("https://a.com")
+                .unwrap()
+                .unwrap()
+                .project_id,
+            None
+        );
         assert!(store.get_pixel("px1").unwrap().is_none());
         // A second source not on the project is left untouched; unknown id -> false.
         assert!(!store.delete_project_cascade("nope").unwrap());
@@ -282,8 +305,10 @@ mod tests {
         let store = temp_store();
         let events = vec![event("https://a.com", 1000), event("pixel://01HX", 2000)];
         store.append_events(&events).unwrap();
-        let path = std::env::temp_dir()
-            .join(format!("analytics-test-{}-part.parquet", std::process::id()));
+        let path = std::env::temp_dir().join(format!(
+            "analytics-test-{}-part.parquet",
+            std::process::id()
+        ));
         super::write_partition(&events, &path).unwrap();
         let df = super::read_partition(&path).unwrap();
         assert_eq!(df.height(), 2);

--- a/agent/src/store/parquet.rs
+++ b/agent/src/store/parquet.rs
@@ -67,7 +67,10 @@ pub fn write_partition(events: &[StoredEvent], path: &Path) -> Result<()> {
     }
     let mut df = build_dataframe(events).or_system_err(STORAGE_ADVICE)?;
 
-    let file_name = path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
     let tmp = path.with_file_name(format!("{file_name}.tmp"));
     {
         let file = std::fs::File::create(&tmp).or_system_err(STORAGE_ADVICE)?;
@@ -83,5 +86,7 @@ pub fn write_partition(events: &[StoredEvent], path: &Path) -> Result<()> {
 /// queries).
 pub fn read_partition(path: &Path) -> Result<DataFrame> {
     let file = std::fs::File::open(path).or_system_err(STORAGE_ADVICE)?;
-    ParquetReader::new(file).finish().or_system_err(STORAGE_ADVICE)
+    ParquetReader::new(file)
+        .finish()
+        .or_system_err(STORAGE_ADVICE)
 }

--- a/agent/src/store/schema.rs
+++ b/agent/src/store/schema.rs
@@ -60,7 +60,10 @@ fn apply(_db: &Database, version: u32) -> Result<()> {
 fn read_version(db: &Database) -> Result<u32> {
     let txn = db.begin_read().or_system_err(OPEN_ADVICE)?;
     let table = txn.open_table(META).or_system_err(OPEN_ADVICE)?;
-    match table.get(META_SCHEMA_VERSION).or_system_err(STORAGE_ADVICE)? {
+    match table
+        .get(META_SCHEMA_VERSION)
+        .or_system_err(STORAGE_ADVICE)?
+    {
         Some(value) => Ok(u32_from_be(value.value())),
         None => Ok(0),
     }
@@ -86,8 +89,11 @@ mod tests {
     fn temp_db() -> (Database, std::path::PathBuf) {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-        let path = std::env::temp_dir()
-            .join(format!("analytics-schema-{}-{}.redb", std::process::id(), n));
+        let path = std::env::temp_dir().join(format!(
+            "analytics-schema-{}-{}.redb",
+            std::process::id(),
+            n
+        ));
         let _ = std::fs::remove_file(&path);
         let db = Database::create(&path).unwrap();
         // The meta table must exist before version reads/writes.

--- a/agent/src/web/api/auth.rs
+++ b/agent/src/web/api/auth.rs
@@ -77,8 +77,13 @@ pub async fn auth_login(
 
     let pkce = generate_pkce();
     let csrf_state = random_token();
-    let authorize = match authorize_url(oidc, &discovery, &redirect_uri, &csrf_state, &pkce.challenge)
-    {
+    let authorize = match authorize_url(
+        oidc,
+        &discovery,
+        &redirect_uri,
+        &csrf_state,
+        &pkce.challenge,
+    ) {
         Ok(url) => url,
         Err(err) => {
             error!("Failed to build the OIDC authorization URL: {err}");
@@ -233,7 +238,9 @@ fn csrf_ok(req: &HttpRequest) -> bool {
         .get(super::CSRF_HEADER)
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
-    let cookie = req.cookie(super::CSRF_COOKIE).map(|c| c.value().to_string());
+    let cookie = req
+        .cookie(super::CSRF_COOKIE)
+        .map(|c| c.value().to_string());
     match (header, cookie) {
         (Some(header), Some(cookie)) => !header.is_empty() && header == cookie,
         _ => false,

--- a/agent/src/web/api/exceptions.rs
+++ b/agent/src/web/api/exceptions.rs
@@ -37,8 +37,11 @@ pub async fn list_all(state: web::Data<AppState>, query: web::Query<StatsQuery>)
         for pixel in store.list_pixels()? {
             uri_project.insert(pixel_source(&pixel.id), pixel.project_id);
         }
-        let project_names: HashMap<String, String> =
-            store.list_projects()?.into_iter().map(|p| (p.id, p.name)).collect();
+        let project_names: HashMap<String, String> = store
+            .list_projects()?
+            .into_iter()
+            .map(|p| (p.id, p.name))
+            .collect();
 
         // Fold per-(fingerprint, source) rows up to per-(fingerprint, project) rows
         // so a project's count matches its detail page. Unassigned sources are keyed
@@ -57,7 +60,12 @@ pub async fn list_all(state: web::Data<AppState>, query: web::Query<StatsQuery>)
                     g.last_seen_ms = g.last_seen_ms.max(group.last_seen_ms);
                 }
                 Entry::Vacant(e) => {
-                    e.insert(GlobalException { group, project_id, project_name: None, source });
+                    e.insert(GlobalException {
+                        group,
+                        project_id,
+                        project_name: None,
+                        source,
+                    });
                 }
             }
         }
@@ -83,7 +91,10 @@ pub async fn list_all(state: web::Data<AppState>, query: web::Query<StatsQuery>)
         Ok(Err(err)) => internal_error(err),
         Err(err) => {
             error!("global exception listing task failed: {err}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load exceptions.")
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load exceptions.",
+            )
         }
     }
 }
@@ -117,7 +128,10 @@ pub async fn list(
         Ok(Err(err)) => internal_error(err),
         Err(err) => {
             error!("exception listing task failed: {err}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load exceptions.")
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load exceptions.",
+            )
         }
     }
 }
@@ -143,26 +157,28 @@ pub async fn detail(
     let store = state.store.clone();
     let parquet_dir = state.config.storage.parquet_dir.clone();
 
-    let result = web::block(move || -> crate::errors::Result<Option<ExceptionGroupDetail>> {
-        let sources = analytics::project_source_uris(&store, &project_id)?;
-        let Some((mut group, occurrences)) = analytics::exception_detail(
-            &store,
-            &parquet_dir,
-            &sources,
-            &group_id,
-            from,
-            to,
-            OCCURRENCE_LIMIT,
-        )?
-        else {
-            return Ok(None);
-        };
-        if let Some(triage) = store.get_triage(&project_id, &group_id)? {
-            group.status = triage.status;
-            group.note = triage.note;
-        }
-        Ok(Some(ExceptionGroupDetail { group, occurrences }))
-    })
+    let result = web::block(
+        move || -> crate::errors::Result<Option<ExceptionGroupDetail>> {
+            let sources = analytics::project_source_uris(&store, &project_id)?;
+            let Some((mut group, occurrences)) = analytics::exception_detail(
+                &store,
+                &parquet_dir,
+                &sources,
+                &group_id,
+                from,
+                to,
+                OCCURRENCE_LIMIT,
+            )?
+            else {
+                return Ok(None);
+            };
+            if let Some(triage) = store.get_triage(&project_id, &group_id)? {
+                group.status = triage.status;
+                group.note = triage.note;
+            }
+            Ok(Some(ExceptionGroupDetail { group, occurrences }))
+        },
+    )
     .await;
 
     match result {
@@ -171,7 +187,10 @@ pub async fn detail(
         Ok(Err(err)) => internal_error(err),
         Err(err) => {
             error!("exception detail task failed: {err}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load the exception.")
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load the exception.",
+            )
         }
     }
 }
@@ -197,7 +216,10 @@ pub async fn triage(
         updated_by,
     };
 
-    match state.store.put_triage(&input.project_id, &group_id, &triage) {
+    match state
+        .store
+        .put_triage(&input.project_id, &group_id, &triage)
+    {
         Ok(()) => HttpResponse::NoContent().finish(),
         Err(err) => internal_error(err),
     }

--- a/agent/src/web/api/mod.rs
+++ b/agent/src/web/api/mod.rs
@@ -143,7 +143,8 @@ pub async fn api_auth(
                 let response = unauthenticated(&state, &req);
                 return Ok(req.into_response(response));
             }
-            Some(token) => match validate_token(&state.http, &state.oidc_cache, oidc, &token).await {
+            Some(token) => match validate_token(&state.http, &state.oidc_cache, oidc, &token).await
+            {
                 Ok(claims) => Some(claims),
                 Err(err) => {
                     info!("Rejected API request with an invalid session cookie: {err}");
@@ -209,7 +210,9 @@ fn csrf_ok(req: &ServiceRequest) -> bool {
         .get(CSRF_HEADER)
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
-    let cookie = req.cookie(CSRF_COOKIE).map(|c: Cookie| c.value().to_string());
+    let cookie = req
+        .cookie(CSRF_COOKIE)
+        .map(|c: Cookie| c.value().to_string());
     match (header, cookie) {
         (Some(header), Some(cookie)) => !header.is_empty() && header == cookie,
         _ => false,

--- a/agent/src/web/api/overview.rs
+++ b/agent/src/web/api/overview.rs
@@ -22,7 +22,10 @@ pub async fn overview(state: web::Data<AppState>, query: web::Query<StatsQuery>)
         Ok(Err(err)) => internal_error(err),
         Err(err) => {
             error!("overview computation task failed: {err}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to compute the overview.")
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to compute the overview.",
+            )
         }
     }
 }

--- a/agent/src/web/api/pixels.rs
+++ b/agent/src/web/api/pixels.rs
@@ -13,8 +13,10 @@ pub async fn list(state: web::Data<AppState>, path: web::Path<String>) -> HttpRe
     let project_id = path.into_inner();
     match state.store.list_pixels() {
         Ok(pixels) => {
-            let mut pixels: Vec<Pixel> =
-                pixels.into_iter().filter(|p| p.project_id == project_id).collect();
+            let mut pixels: Vec<Pixel> = pixels
+                .into_iter()
+                .filter(|p| p.project_id == project_id)
+                .collect();
             pixels.sort_by_key(|p| p.name.to_lowercase());
             HttpResponse::Ok().json(pixels)
         }

--- a/agent/src/web/api/projects.rs
+++ b/agent/src/web/api/projects.rs
@@ -29,7 +29,10 @@ pub async fn create(state: web::Data<AppState>, body: web::Json<ProjectInput>) -
     }
     let project = Project {
         id: ulid::Ulid::new().to_string(),
-        slug: input.slug.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| slugify(&name)),
+        slug: input
+            .slug
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| slugify(&name)),
         name,
         created_at: Utc::now(),
     };
@@ -61,7 +64,10 @@ pub async fn update(
     let input = body.into_inner();
     let name = input.name.trim().to_string();
     let updated = Project {
-        slug: input.slug.filter(|s| !s.trim().is_empty()).unwrap_or(existing.slug),
+        slug: input
+            .slug
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or(existing.slug),
         name: if name.is_empty() { existing.name } else { name },
         ..existing
     };
@@ -86,7 +92,10 @@ pub async fn delete(state: web::Data<AppState>, path: web::Path<String>) -> Http
         Ok(Err(err)) => internal_error(err),
         Err(err) => {
             error!("project delete task failed: {err}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to delete the project.")
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to delete the project.",
+            )
         }
     }
 }
@@ -122,7 +131,10 @@ pub async fn stats(
         Ok(Err(err)) => internal_error(err),
         Err(err) => {
             error!("stats computation task failed: {err}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to compute statistics.")
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to compute statistics.",
+            )
         }
     }
 }
@@ -141,5 +153,9 @@ fn slugify(name: &str) -> String {
         }
     }
     let slug = slug.trim_matches('-').to_string();
-    if slug.is_empty() { "project".to_string() } else { slug }
+    if slug.is_empty() {
+        "project".to_string()
+    } else {
+        slug
+    }
 }

--- a/agent/src/web/helpers/oidc.rs
+++ b/agent/src/web/helpers/oidc.rs
@@ -28,7 +28,17 @@ const ADVICE_REAUTH: &[&str] = &["Sign in again to obtain a fresh session."];
 
 /// JWT claims carrying protocol semantics, hidden from the ACL filter.
 const EXCLUDED_CLAIMS: &[&str] = &[
-    "exp", "nbf", "iat", "iss", "aud", "jti", "nonce", "at_hash", "c_hash", "azp", "auth_time",
+    "exp",
+    "nbf",
+    "iat",
+    "iss",
+    "aud",
+    "jti",
+    "nonce",
+    "at_hash",
+    "c_hash",
+    "azp",
+    "auth_time",
 ];
 
 const CACHE_TTL: Duration = Duration::from_secs(60 * 60);
@@ -98,7 +108,10 @@ pub fn generate_pkce() -> PkcePair {
         uuid::Uuid::new_v4().simple()
     );
     let challenge = base64url(Sha256::digest(verifier.as_bytes()).as_slice());
-    PkcePair { verifier, challenge }
+    PkcePair {
+        verifier,
+        challenge,
+    }
 }
 
 /// Generate an opaque random token for use as OAuth `state` or a CSRF token.
@@ -181,7 +194,10 @@ fn json_to_filter_value(value: &serde_json::Value) -> FilterValue<'static> {
     match value {
         serde_json::Value::Null => FilterValue::Null,
         serde_json::Value::Bool(b) => FilterValue::Bool(*b),
-        serde_json::Value::Number(n) => n.as_f64().map(FilterValue::Number).unwrap_or(FilterValue::Null),
+        serde_json::Value::Number(n) => n
+            .as_f64()
+            .map(FilterValue::Number)
+            .unwrap_or(FilterValue::Null),
         serde_json::Value::String(s) => FilterValue::String(Cow::Owned(s.clone())),
         serde_json::Value::Array(items) => {
             FilterValue::Tuple(items.iter().map(json_to_filter_value).collect())
@@ -207,12 +223,21 @@ pub async fn discovery(
         .get(&url)
         .send()
         .await
-        .wrap_system_err("Failed to fetch the OIDC discovery document.", ADVICE_PROVIDER)?
+        .wrap_system_err(
+            "Failed to fetch the OIDC discovery document.",
+            ADVICE_PROVIDER,
+        )?
         .error_for_status()
-        .wrap_system_err("The OIDC provider returned an error for its discovery document.", ADVICE_PROVIDER)?
+        .wrap_system_err(
+            "The OIDC provider returned an error for its discovery document.",
+            ADVICE_PROVIDER,
+        )?
         .json()
         .await
-        .wrap_system_err("Failed to parse the OIDC discovery document.", ADVICE_PROVIDER)?;
+        .wrap_system_err(
+            "Failed to parse the OIDC discovery document.",
+            ADVICE_PROVIDER,
+        )?;
     cache.store_discovery(document.clone());
     Ok(document)
 }
@@ -225,9 +250,15 @@ async fn fetch_jwks(
     http.get(&discovery.jwks_uri)
         .send()
         .await
-        .wrap_system_err("Failed to fetch the OIDC signing keys (JWKS).", ADVICE_PROVIDER)?
+        .wrap_system_err(
+            "Failed to fetch the OIDC signing keys (JWKS).",
+            ADVICE_PROVIDER,
+        )?
         .error_for_status()
-        .wrap_system_err("The OIDC provider returned an error for its signing keys.", ADVICE_PROVIDER)?
+        .wrap_system_err(
+            "The OIDC provider returned an error for its signing keys.",
+            ADVICE_PROVIDER,
+        )?
         .json()
         .await
         .wrap_system_err("Failed to parse the OIDC signing keys.", ADVICE_PROVIDER)
@@ -281,8 +312,10 @@ fn verify_token(
     key_set: &jsonwebtoken::jwk::JwkSet,
     token: &str,
 ) -> Result<serde_json::Map<String, serde_json::Value>> {
-    let header = jsonwebtoken::decode_header(token)
-        .wrap_user_err("The admin session token could not be decoded.", ADVICE_REAUTH)?;
+    let header = jsonwebtoken::decode_header(token).wrap_user_err(
+        "The admin session token could not be decoded.",
+        ADVICE_REAUTH,
+    )?;
 
     // Reject symmetric algorithms to prevent algorithm-confusion attacks against
     // the asymmetric keys published via JWKS.
@@ -299,10 +332,16 @@ fn verify_token(
     }
 
     let kid = header.kid.ok_or_else(|| {
-        human_errors::user("The admin session token does not identify a signing key.", ADVICE_REAUTH)
+        human_errors::user(
+            "The admin session token does not identify a signing key.",
+            ADVICE_REAUTH,
+        )
     })?;
     let jwk = key_set.find(&kid).ok_or_else(|| {
-        human_errors::user("The admin session token was signed with an unknown key.", ADVICE_REAUTH)
+        human_errors::user(
+            "The admin session token was signed with an unknown key.",
+            ADVICE_REAUTH,
+        )
     })?;
     let decoding_key = jsonwebtoken::DecodingKey::from_jwk(jwk).wrap_system_err(
         "Failed to construct a verification key from the provider's JWKS.",
@@ -347,7 +386,10 @@ pub async fn exchange_code(
         .form(&params)
         .send()
         .await
-        .wrap_system_err("Failed to exchange the authorization code.", ADVICE_PROVIDER)?
+        .wrap_system_err(
+            "Failed to exchange the authorization code.",
+            ADVICE_PROVIDER,
+        )?
         .error_for_status()
         .wrap_user_err(
             "The OIDC provider rejected the authorization code exchange.",
@@ -355,7 +397,10 @@ pub async fn exchange_code(
         )?
         .json()
         .await
-        .wrap_system_err("Failed to parse the token response from the provider.", ADVICE_PROVIDER)?;
+        .wrap_system_err(
+            "Failed to parse the token response from the provider.",
+            ADVICE_PROVIDER,
+        )?;
     Ok(response.id_token)
 }
 

--- a/agent/src/web/track/gif.rs
+++ b/agent/src/web/track/gif.rs
@@ -40,6 +40,9 @@ pub async fn gif(state: web::Data<AppState>, path: web::Path<String>) -> HttpRes
 
     HttpResponse::Ok()
         .content_type("image/gif")
-        .insert_header((CACHE_CONTROL, "no-store, no-cache, must-revalidate, private"))
+        .insert_header((
+            CACHE_CONTROL,
+            "no-store, no-cache, must-revalidate, private",
+        ))
         .body(BLANK_GIF)
 }

--- a/agent/src/web/track/mod.rs
+++ b/agent/src/web/track/mod.rs
@@ -20,23 +20,24 @@ const MAX_TRACK_BODY: usize = 16 * 1024;
 
 /// Register `/tracker.js` and the CORS-enabled `/track/*` endpoints.
 pub fn configure(cfg: &mut web::ServiceConfig) {
-    cfg.route("/tracker.js", web::get().to(tracker::tracker_js)).service(
-        // Beacons are sent cross-origin from tracked sites. Hits and exceptions are
-        // posted as `text/plain` so they are CORS "simple requests" (no preflight) and
-        // can be sent with `mode: "no-cors"`; `beacon_json_config` makes the JSON
-        // extractor accept that content type. The `/ping` GET still needs CORS to
-        // expose its JSON response to the page, so the scope stays permissively
-        // CORS-enabled. No credentials are involved. Rate limiting runs as middleware
-        // so over-limit requests are rejected before their bodies are read/parsed.
-        web::scope("/track")
-            .app_data(beacon_json_config())
-            .wrap(from_fn(rate_limit))
-            .wrap(Cors::permissive())
-            .route("/ping", web::get().to(ping::ping))
-            .route("/hit", web::post().to(hit::hit))
-            .route("/exception", web::post().to(exception::exception))
-            .route("/gif/{id}", web::get().to(gif::gif)),
-    );
+    cfg.route("/tracker.js", web::get().to(tracker::tracker_js))
+        .service(
+            // Beacons are sent cross-origin from tracked sites. Hits and exceptions are
+            // posted as `text/plain` so they are CORS "simple requests" (no preflight) and
+            // can be sent with `mode: "no-cors"`; `beacon_json_config` makes the JSON
+            // extractor accept that content type. The `/ping` GET still needs CORS to
+            // expose its JSON response to the page, so the scope stays permissively
+            // CORS-enabled. No credentials are involved. Rate limiting runs as middleware
+            // so over-limit requests are rejected before their bodies are read/parsed.
+            web::scope("/track")
+                .app_data(beacon_json_config())
+                .wrap(from_fn(rate_limit))
+                .wrap(Cors::permissive())
+                .route("/ping", web::get().to(ping::ping))
+                .route("/hit", web::post().to(hit::hit))
+                .route("/exception", web::post().to(exception::exception))
+                .route("/gif/{id}", web::get().to(gif::gif)),
+        );
 }
 
 /// JSON body configuration for the beacon endpoints. Caps the body well below actix's

--- a/agent/src/web/track/tracker.rs
+++ b/agent/src/web/track/tracker.rs
@@ -5,11 +5,13 @@
 //! exists (with a placeholder) even when the beacon has not been built, so the agent
 //! always compiles.
 
-use actix_web::http::header::CACHE_CONTROL;
 use actix_web::HttpResponse;
+use actix_web::http::header::CACHE_CONTROL;
 
-const TRACKER_JS: &str =
-    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../tracker/dist/tracker.js"));
+const TRACKER_JS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../tracker/dist/tracker.js"
+));
 
 pub async fn tracker_js() -> HttpResponse {
     HttpResponse::Ok()

--- a/api/src/source.rs
+++ b/api/src/source.rs
@@ -59,7 +59,10 @@ pub struct SourceInput {
 
 /// Canonical website source URI for a hostname.
 pub fn website_source(hostname: &str) -> String {
-    format!("https://{}", hostname.trim().trim_end_matches('.').to_lowercase())
+    format!(
+        "https://{}",
+        hostname.trim().trim_end_matches('.').to_lowercase()
+    )
 }
 
 /// Source URI for an application.

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1736029545,
-        "narHash": "sha256-b3xcFSmdu1uPNx4dQZNX8i0yHilxSnMrAIaoATHSWXg=",
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "61c8f051c16c46bc95835cedd80e21b0e5a86d85",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1735972386,
-        "narHash": "sha256-5bqhkfe/dAxUGFSHz+4zpXSZONaB+KziQiWSnLPC1Ao=",
+        "lastModified": 1781430890,
+        "narHash": "sha256-Dict8ZPqm3fei8iFXh75sPBNPqCdn7a8GJytgLajbGw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "16a543b819f511df865fb515f19fb84f4066c3f4",
+        "rev": "1b9586dd32bb28519cf6eea855e2df5b4d5eca15",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735915915,
-        "narHash": "sha256-Q4HuFAvoKAIiTRZTUxJ0ZXeTC7lLfC9/dggGHNXNlCw=",
+        "lastModified": 1781359544,
+        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a27871180d30ebee8aa6b11bf7fef8a52f024733",
+        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     fenix = {
       url = "github:nix-community/fenix";

--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,10 @@
         uiDistFilter = path: _type: builtins.match ".*/ui/dist/.*" path != null;
         # Likewise the built tracking beacon, embedded via include_str!.
         trackerDistFilter = path: _type: builtins.match ".*/tracker/dist/.*" path != null;
+        # The example config is embedded via include_str! and exercised by tests.
+        configExampleFilter = path: _type: builtins.match ".*/config\.example\.yaml$" path != null;
         sourceFilter = path: type:
-          (gifDataFilter path type) || (uiDistFilter path type) || (trackerDistFilter path type) || (craneLib.filterCargoSources path type);
+          (gifDataFilter path type) || (uiDistFilter path type) || (trackerDistFilter path type) || (configExampleFilter path type) || (craneLib.filterCargoSources path type);
 
         src = lib.cleanSourceWith {
           src = ./.;
@@ -106,6 +108,13 @@
           # Audit dependencies
           analytics-audit = craneLib.cargoAudit {
             inherit src advisory-db;
+
+            # RUSTSEC-2023-0071 (Marvin timing sidechannel in `rsa`) is pulled in
+            # transitively via jsonwebtoken and has no fixed upgrade available. It
+            # only affects RSA private-key operations, which the agent does not
+            # perform (JWTs are verified with provider public keys), so accept it.
+            # `yanked` is ignored because the sandbox has no crates.io index.
+            cargoAuditExtraArgs = "--ignore yanked --ignore RUSTSEC-2023-0071";
           };
 
           # Audit licenses


### PR DESCRIPTION
## What

The `Nix` workflow (`nix build .#` and `nix flake check`) was failing. This gets it green and, as requested, modernises the crane setup to match [SierraSoftworks/grey](https://github.com/SierraSoftworks/grey/blob/main/flake.nix).

## Why it was red (on current `main`)

Two latent issues in the flake checks, only reachable once the crate actually compiles:

1. **`config.example.yaml` was missing from crane's source filter.** The `config::tests::example_config_loads` test embeds it via `include_str!`, so the `clippy` (`--all-targets`) and `nextest` checks failed to compile. It's now included alongside the existing `gif` / `ui/dist` / `tracker/dist` inclusions.
2. **`cargo-audit` flagged `RUSTSEC-2023-0071`** (Marvin timing side-channel in `rsa`, pulled in transitively via `jsonwebtoken`). No fixed upgrade is available, and the agent never performs RSA private-key operations (JWTs are verified with the provider's public key), so the advisory is ignored with a documented rationale. `yanked` is also ignored because the build sandbox has no crates.io index.

## crane update

- `flake.nix`: dropped the now-removed `inputs.nixpkgs.follows` on crane (the latest crane declares no `nixpkgs` input).
- `flake.lock`: bumped crane to latest — which requires `nixpkgs >= 25.11` — plus nixpkgs (`nixpkgs-unstable`) and fenix.
- The newer toolchain ships rustfmt 1.95, whose import-ordering/wrapping rules differ slightly, so the tree is reformatted to keep `analytics-fmt` green. No functional changes.

## Note on the original symptom

The build first appeared to fail on a crate-vendoring checksum mismatch (`convert_case`), which traced back to a botched `Cargo.lock` merge in `ff7ac8e`. That has since been resolved independently on `main` (the dashboard-redesign work regenerated the lockfile), so **no `Cargo.lock` change is needed here** — confirmed with `cargo metadata --locked` (zero drift).

## Verification

On this branch, both `nix build .#` and `nix flake check` pass locally — all seven checks (`analytics`, `clippy`, `doc`, `fmt`, `audit`, `deny`, `nextest`) are green.

https://claude.ai/code/session_01Ff4nAQBJQ1sPmgYnYDFBiY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ff4nAQBJQ1sPmgYnYDFBiY)_