### PR TITLE
fix: Resolve clippy 1.95 warnings in the ui crate

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,3 +1,8 @@
+# Standalone workspace: this crate is excluded from the repo root's workspace,
+# and without this cargo walks past it to whatever manifest sits above the
+# checkout (e.g. when building from a nested git worktree).
+[workspace]
+
 [package]
 name = "analytics-ui"
 description = "Client-side-rendered Yew dashboard for the analytics service."

--- a/ui/src/components/filter_bar.rs
+++ b/ui/src/components/filter_bar.rs
@@ -287,8 +287,8 @@ fn add_filter(props: &AddFilterProps) -> Html {
             let onkeydown = {
                 let submit = submit.clone();
                 let (text, options) = (text.clone(), options.clone());
-                Callback::from(move |e: KeyboardEvent| match e.key().as_str() {
-                    "Enter" => {
+                Callback::from(move |e: KeyboardEvent| {
+                    if e.key() == "Enter" {
                         e.prevent_default();
                         let typed = text.trim().to_string();
                         if !typed.is_empty() {
@@ -297,7 +297,6 @@ fn add_filter(props: &AddFilterProps) -> Html {
                             submit(dim, first.value.clone());
                         }
                     }
-                    _ => {}
                 })
             };
             let back = {

--- a/ui/src/filters.rs
+++ b/ui/src/filters.rs
@@ -355,7 +355,7 @@ impl Query {
         let Ok(filter) = Filter::new(advanced.as_str()) else {
             return Vec::new();
         };
-        filter.visit(&mut FieldCollector::default())
+        filter.visit(&mut FieldCollector)
     }
 }
 

--- a/ui/src/pages/dashboard.rs
+++ b/ui/src/pages/dashboard.rs
@@ -335,7 +335,7 @@ pub fn dashboard() -> Html {
     let project_filter = filters.get(Dim::Project).map(str::to_string);
     let heading = project_filter
         .as_deref()
-        .map(|id| project_name(id))
+        .map(&project_name)
         .unwrap_or_else(|| "Dashboard".to_string());
     let subtitle = if project_filter.is_some() {
         "Traffic for this project — click any value to filter, remove the chip to zoom back out."

--- a/ui/src/pages/exceptions.rs
+++ b/ui/src/pages/exceptions.rs
@@ -25,7 +25,7 @@ thread_local! {
     /// The last-used status tab and text filter, so a detail round-trip (or any
     /// navigation) restores the inbox the way the operator left it.
     static INBOX_VIEW: RefCell<(StatusTab, String)> =
-        RefCell::new((StatusTab::Unresolved, String::new()));
+        const { RefCell::new((StatusTab::Unresolved, String::new())) };
 }
 
 /// The status tabs across the top of the inbox.


### PR DESCRIPTION
## Summary
- Fixes the four warnings that appeared in the `ui` crate with the clippy 1.95 toolchain update, so `cargo clippy --all-targets` in `ui/` is warning-free again:
  - `ui/src/components/filter_bar.rs` — replaced a single-arm `match` on the pressed key with an `if e.key() == "Enter"` check
  - `ui/src/filters.rs` — construct the unit struct `FieldCollector` directly instead of via `Default`
  - `ui/src/pages/dashboard.rs` — pass `&project_name` to `.map()` instead of wrapping it in a redundant closure
  - `ui/src/pages/exceptions.rs` — made the `INBOX_VIEW` thread-local initializer a `const` block
- Adds an empty `[workspace]` table to `ui/Cargo.toml`. The crate is excluded from the root workspace by path, so when building from a nested git worktree cargo walked up past the worktree and collided with the outer checkout's workspace manifest. The empty table makes the exclusion self-contained (this is the companion cargo itself recommends for excluded packages) and changes nothing for normal checkouts.

## Testing
- `cargo clippy --all-targets` in `ui/` — no warnings
- `cargo check` in `ui/` — passes
- `cargo test` in `ui/` — passes (the crate currently has no test functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)