### PR TITLE
Renew admin sessions from OIDC refresh tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "url",
  "uuid",
  "vergen",
+ "wiremock",
  "woothee",
 ]
 
@@ -382,6 +383,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +502,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "itoa",
@@ -516,7 +527,7 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.2.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -1093,6 +1104,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,16 +1640,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1680,6 +1709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,12 +1760,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1741,7 +1775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1752,7 +1786,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -1802,15 +1836,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "futures-core",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -1828,7 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1864,7 +1899,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
@@ -2461,6 +2496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,7 +2556,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.2",
  "http-body-util",
  "humantime",
  "hyper",
@@ -2580,7 +2625,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.2.0",
+ "http 1.4.2",
  "opentelemetry",
  "reqwest 0.13.2",
 ]
@@ -2591,7 +2636,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.2.0",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -3794,8 +3839,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3838,8 +3883,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4744,8 +4789,8 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4818,7 +4863,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "iri-string",
@@ -5069,7 +5114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
 dependencies = [
  "base64",
- "http 1.2.0",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -5682,6 +5727,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -38,5 +38,8 @@ redb.workspace = true
 ulid.workspace = true
 polars.workspace = true
 
+[dev-dependencies]
+wiremock = "0.6"
+
 [build-dependencies]
 vergen = { version = "8.3", features = ["git", "gitcl"] }

--- a/agent/src/web/api/auth.rs
+++ b/agent/src/web/api/auth.rs
@@ -1,6 +1,9 @@
 //! Server-driven OIDC session endpoints and the CSRF token endpoint. The agent
 //! performs the whole Authorization Code + PKCE exchange so the browser never
-//! handles tokens or the client secret. Ported from SierraSoftworks/automate.
+//! handles tokens or the client secret. Ported from SierraSoftworks/automate,
+//! with the session-renewal flow modelled on SierraSoftworks/grey: when the
+//! provider issues a refresh token it is kept in a second `HttpOnly` cookie and
+//! redeemed via `/refresh`, so an expired ID token no longer ends the session.
 
 use actix_web::cookie::time::Duration as CookieDuration;
 use actix_web::cookie::{Cookie, SameSite};
@@ -10,16 +13,25 @@ use actix_web::{HttpRequest, HttpResponse, web};
 use serde::{Deserialize, Serialize};
 use tracing_batteries::prelude::*;
 
-use super::{CSRF_COOKIE, OAUTH_COOKIE, SESSION_COOKIE, json_error};
+use super::{CSRF_COOKIE, OAUTH_COOKIE, REFRESH_COOKIE, SESSION_COOKIE, json_error};
 use crate::state::AppState;
 use crate::web::extract::{base_url, is_https};
 use crate::web::helpers::oidc::{
-    authorize_url, discovery, exchange_code, generate_pkce, random_token, validate_token,
+    authorize_url, discovery, exchange_code, generate_pkce, random_token, refresh_tokens,
+    validate_token,
 };
 
 const DEFAULT_SESSION_SECONDS: i64 = 8 * 60 * 60;
 const OAUTH_STATE_SECONDS: i64 = 10 * 60;
+/// How long the refresh-token cookie survives. This only bounds how long the
+/// *browser* keeps the cookie — the provider decides whether the token inside is
+/// still redeemable, so a stale cookie simply fails the grant and falls back to
+/// an interactive sign-in.
+const REFRESH_COOKIE_SECONDS: i64 = 30 * 24 * 60 * 60;
 const COOKIE_PATH: &str = "/";
+/// The auth-scoped cookies (in-flight OAuth state and the refresh token) are only
+/// needed by the endpoints under this path, so they never travel with ordinary
+/// API requests.
 const OAUTH_COOKIE_PATH: &str = "/api/v1/auth";
 
 /// Transient state persisted across the redirect to the identity provider.
@@ -163,7 +175,7 @@ pub async fn auth_callback(
         }
     };
 
-    let id_token = match exchange_code(
+    let tokens = match exchange_code(
         &state.http,
         oidc,
         &discovery,
@@ -173,14 +185,15 @@ pub async fn auth_callback(
     )
     .await
     {
-        Ok(token) => token,
+        Ok(tokens) => tokens,
         Err(err) => {
             warn!("OIDC token exchange failed: {err}");
             return clear_oauth_and_redirect("/?auth_error=exchange");
         }
     };
 
-    let claims = match validate_token(&state.http, &state.oidc_cache, oidc, &id_token).await {
+    let claims = match validate_token(&state.http, &state.oidc_cache, oidc, &tokens.id_token).await
+    {
         Ok(claims) => claims,
         Err(err) => {
             warn!("OIDC provider issued an ID token that failed validation: {err}");
@@ -188,6 +201,107 @@ pub async fn auth_callback(
         }
     };
 
+    let mut oauth_removal = Cookie::build(OAUTH_COOKIE, "")
+        .path(OAUTH_COOKIE_PATH)
+        .finish();
+    oauth_removal.make_removal();
+
+    let mut response = HttpResponse::Found();
+    response
+        .cookie(session_cookie(tokens.id_token, &claims, secure))
+        .cookie(oauth_removal);
+    match tokens.refresh_token {
+        Some(refresh) => {
+            response.cookie(refresh_cookie(refresh, secure));
+        }
+        // No refresh token issued: drop any leftover from a previous session so a
+        // stale token can't shadow this (non-renewable) one.
+        None => {
+            response.cookie(refresh_cookie_removal());
+        }
+    }
+    response
+        .insert_header((LOCATION, oauth_state.return_to))
+        .finish()
+}
+
+/// `POST /api/v1/auth/refresh` — renew the session by redeeming the refresh-token
+/// cookie, re-issuing the session cookie without another interactive sign-in.
+///
+/// Like `/logout` this lives in the public `/auth` scope (an expired session must
+/// still be able to renew itself), but unlike logout it needs no CSRF check: the
+/// refresh cookie is `SameSite=Lax`, so a forged cross-site `POST` never carries
+/// it and simply fails with a 401.
+pub async fn auth_refresh(state: web::Data<AppState>, req: HttpRequest) -> HttpResponse {
+    let secure = is_https(state.config.web.trust_proxy, &req);
+
+    let Some(oidc) = state.config.web.admin.oidc.as_ref() else {
+        // No identity provider: there is no session to renew.
+        return expired_session();
+    };
+
+    let Some(refresh_token) = req
+        .cookie(REFRESH_COOKIE)
+        .map(|c| c.value().to_string())
+        .filter(|token| !token.is_empty())
+    else {
+        return expired_session();
+    };
+
+    let discovery = match discovery(&state.http, &state.oidc_cache, oidc).await {
+        Ok(d) => d,
+        Err(err) => {
+            error!("Failed to load OIDC discovery document during session renewal: {err}");
+            return json_error(
+                StatusCode::BAD_GATEWAY,
+                "We could not reach the configured identity provider.",
+            );
+        }
+    };
+
+    let tokens = match refresh_tokens(&state.http, oidc, &discovery, &refresh_token).await {
+        Ok(tokens) => tokens,
+        // The provider rejected the grant (revoked/expired/rotated-away token):
+        // the session is over, so drop both cookies and ask for a fresh sign-in.
+        Err(err) if err.is(human_errors::Kind::User) => {
+            info!("The OIDC provider rejected the session renewal: {err}");
+            return expired_session();
+        }
+        // A transport/provider failure says nothing about the session itself;
+        // keep the cookies so renewal can be retried once the provider recovers.
+        Err(err) => {
+            error!("OIDC session renewal failed: {err}");
+            return json_error(
+                StatusCode::BAD_GATEWAY,
+                "We could not reach the configured identity provider.",
+            );
+        }
+    };
+
+    let claims = match validate_token(&state.http, &state.oidc_cache, oidc, &tokens.id_token).await
+    {
+        Ok(claims) => claims,
+        Err(err) => {
+            warn!("OIDC provider issued an ID token that failed validation during renewal: {err}");
+            return expired_session();
+        }
+    };
+
+    let mut response = HttpResponse::NoContent();
+    response.cookie(session_cookie(tokens.id_token, &claims, secure));
+    if let Some(refresh) = tokens.refresh_token {
+        response.cookie(refresh_cookie(refresh, secure));
+    }
+    response.finish()
+}
+
+/// Build the session cookie for a freshly validated ID token, living as long as
+/// the token itself does.
+fn session_cookie(
+    id_token: String,
+    claims: &serde_json::Map<String, serde_json::Value>,
+    secure: bool,
+) -> Cookie<'static> {
     let max_age = claims
         .get("exp")
         .and_then(|v| v.as_i64())
@@ -195,29 +309,52 @@ pub async fn auth_callback(
         .filter(|secs| *secs > 0)
         .unwrap_or(DEFAULT_SESSION_SECONDS);
 
-    let session_cookie = Cookie::build(SESSION_COOKIE, id_token)
+    Cookie::build(SESSION_COOKIE, id_token)
         .path(COOKIE_PATH)
         .http_only(true)
         .secure(secure)
         .same_site(SameSite::Lax)
         .max_age(CookieDuration::seconds(max_age))
-        .finish();
-
-    let mut oauth_removal = Cookie::build(OAUTH_COOKIE, "")
-        .path(OAUTH_COOKIE_PATH)
-        .finish();
-    oauth_removal.make_removal();
-
-    HttpResponse::Found()
-        .cookie(session_cookie)
-        .cookie(oauth_removal)
-        .insert_header((LOCATION, oauth_state.return_to))
         .finish()
 }
 
-/// `POST /api/v1/auth/logout` — clear the session cookie. This endpoint is public
-/// (outside `api_auth`), so it enforces the double-submit CSRF check itself to
-/// prevent a cross-site forced logout.
+/// Build the refresh-token cookie, scoped to the auth endpoints.
+fn refresh_cookie(refresh_token: String, secure: bool) -> Cookie<'static> {
+    Cookie::build(REFRESH_COOKIE, refresh_token)
+        .path(OAUTH_COOKIE_PATH)
+        .http_only(true)
+        .secure(secure)
+        .same_site(SameSite::Lax)
+        .max_age(CookieDuration::seconds(REFRESH_COOKIE_SECONDS))
+        .finish()
+}
+
+fn refresh_cookie_removal() -> Cookie<'static> {
+    let mut removal = Cookie::build(REFRESH_COOKIE, "")
+        .path(OAUTH_COOKIE_PATH)
+        .finish();
+    removal.make_removal();
+    removal
+}
+
+/// A 401 that also clears the session and refresh cookies: the session cannot be
+/// renewed, so the browser should stop presenting its remnants.
+fn expired_session() -> HttpResponse {
+    let mut session_removal = Cookie::build(SESSION_COOKIE, "").path(COOKIE_PATH).finish();
+    session_removal.make_removal();
+
+    let mut response = json_error(
+        StatusCode::UNAUTHORIZED,
+        "Your session has expired. Please sign in again.",
+    );
+    let _ = response.add_cookie(&session_removal);
+    let _ = response.add_cookie(&refresh_cookie_removal());
+    response
+}
+
+/// `POST /api/v1/auth/logout` — clear the session and refresh cookies. This
+/// endpoint is public (outside `api_auth`), so it enforces the double-submit CSRF
+/// check itself to prevent a cross-site forced logout.
 pub async fn auth_logout(req: HttpRequest) -> HttpResponse {
     if !csrf_ok(&req) {
         return json_error(
@@ -227,7 +364,10 @@ pub async fn auth_logout(req: HttpRequest) -> HttpResponse {
     }
     let mut removal = Cookie::build(SESSION_COOKIE, "").path(COOKIE_PATH).finish();
     removal.make_removal();
-    HttpResponse::NoContent().cookie(removal).finish()
+    HttpResponse::NoContent()
+        .cookie(removal)
+        .cookie(refresh_cookie_removal())
+        .finish()
 }
 
 /// Double-submit CSRF check against an `HttpRequest` (the middleware version in

--- a/agent/src/web/api/mod.rs
+++ b/agent/src/web/api/mod.rs
@@ -34,6 +34,9 @@ use crate::web::helpers::oidc::{
 
 /// The `HttpOnly` cookie holding the signed-in administrator's OIDC ID token.
 pub const SESSION_COOKIE: &str = "analytics_session";
+/// The `HttpOnly` cookie holding the OIDC refresh token, scoped to the auth
+/// endpoints so it only travels with session-renewal (and logout) requests.
+pub const REFRESH_COOKIE: &str = "analytics_refresh";
 /// The non-`HttpOnly` cookie holding the double-submit CSRF token.
 pub const CSRF_COOKIE: &str = "analytics_csrf";
 /// The short-lived cookie holding in-flight OAuth state during login.
@@ -62,6 +65,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                 web::scope("/auth")
                     .route("/login", web::get().to(auth::auth_login))
                     .route("/callback", web::get().to(auth::auth_callback))
+                    .route("/refresh", web::post().to(auth::auth_refresh))
                     .route("/logout", web::post().to(auth::auth_logout)),
             )
             .service(

--- a/agent/src/web/helpers/oidc.rs
+++ b/agent/src/web/helpers/oidc.rs
@@ -1,6 +1,6 @@
 //! OpenID Connect machinery for the server-driven admin login: discovery + JWKS
 //! fetching/caching, ID token validation, the authorization-URL builder, the
-//! confidential token exchange, and claim filtering.
+//! confidential token exchange, the refresh-token grant, and claim filtering.
 //!
 //! The agent performs the entire Authorization Code + PKCE exchange itself; the
 //! issued ID token is stored in an `HttpOnly` session cookie and never exposed to
@@ -88,6 +88,15 @@ pub struct OidcDiscovery {
 #[derive(serde::Deserialize)]
 struct ProviderTokenResponse {
     id_token: String,
+    refresh_token: Option<String>,
+}
+
+/// Tokens issued by the provider's token endpoint. `id_token` becomes the session
+/// cookie; `refresh_token` (when the provider issues one) lets the agent renew the
+/// session without another interactive login.
+pub struct TokenSet {
+    pub id_token: String,
+    pub refresh_token: Option<String>,
 }
 
 /// A PKCE verifier and its derived S256 challenge.
@@ -363,7 +372,7 @@ fn verify_token(
     Ok(data.claims)
 }
 
-/// Exchange an authorization code (+ PKCE verifier) for the ID token. The
+/// Exchange an authorization code (+ PKCE verifier) for the issued tokens. The
 /// confidential client secret never leaves the server.
 pub async fn exchange_code(
     http: &reqwest::Client,
@@ -372,7 +381,7 @@ pub async fn exchange_code(
     code: &str,
     code_verifier: &str,
     redirect_uri: &str,
-) -> Result<String> {
+) -> Result<TokenSet> {
     let params = [
         ("grant_type", "authorization_code"),
         ("code", code),
@@ -381,27 +390,76 @@ pub async fn exchange_code(
         ("client_id", oidc.client_id.as_str()),
         ("client_secret", oidc.client_secret.as_str()),
     ];
+    token_request(
+        http,
+        &discovery.token_endpoint,
+        &params,
+        "The OIDC provider rejected the authorization code exchange.",
+        &["Start the sign-in process again from the beginning."],
+    )
+    .await
+}
+
+/// Renew a session from a previously issued refresh token, returning a fresh ID
+/// token (and a rotated refresh token when the provider supplies one). Providers
+/// that don't rotate refresh tokens omit it from the response, so the caller's
+/// token is carried over to keep the session renewable.
+pub async fn refresh_tokens(
+    http: &reqwest::Client,
+    oidc: &OidcConfig,
+    discovery: &OidcDiscovery,
+    refresh_token: &str,
+) -> Result<TokenSet> {
+    let params = [
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", oidc.client_id.as_str()),
+        ("client_secret", oidc.client_secret.as_str()),
+    ];
+    let mut tokens = token_request(
+        http,
+        &discovery.token_endpoint,
+        &params,
+        "The OIDC provider rejected the session renewal.",
+        ADVICE_REAUTH,
+    )
+    .await?;
+    if tokens.refresh_token.is_none() {
+        tokens.refresh_token = Some(refresh_token.to_string());
+    }
+    Ok(tokens)
+}
+
+/// POST a form-encoded grant to the provider's token endpoint and parse the
+/// issued tokens.
+async fn token_request(
+    http: &reqwest::Client,
+    token_endpoint: &str,
+    params: &[(&str, &str)],
+    rejection: &'static str,
+    rejection_advice: &'static [&'static str],
+) -> Result<TokenSet> {
     let response: ProviderTokenResponse = http
-        .post(&discovery.token_endpoint)
-        .form(&params)
+        .post(token_endpoint)
+        .form(params)
         .send()
         .await
         .wrap_system_err(
-            "Failed to exchange the authorization code.",
+            "Failed to reach the OIDC provider's token endpoint.",
             ADVICE_PROVIDER,
         )?
         .error_for_status()
-        .wrap_user_err(
-            "The OIDC provider rejected the authorization code exchange.",
-            &["Start the sign-in process again from the beginning."],
-        )?
+        .wrap_user_err(rejection, rejection_advice)?
         .json()
         .await
         .wrap_system_err(
             "Failed to parse the token response from the provider.",
             ADVICE_PROVIDER,
         )?;
-    Ok(response.id_token)
+    Ok(TokenSet {
+        id_token: response.id_token,
+        refresh_token: response.refresh_token,
+    })
 }
 
 /// Derive the display identity from a validated claim set.
@@ -474,6 +532,129 @@ mod tests {
         assert!(filtered.contains_key("groups"));
         assert!(!filtered.contains_key("exp"));
         assert!(!filtered.contains_key("iss"));
+    }
+
+    /// Build a discovery document pointing every endpoint at the given mock server.
+    fn mock_discovery(base: &str) -> OidcDiscovery {
+        OidcDiscovery {
+            issuer: base.to_string(),
+            authorization_endpoint: format!("{base}/authorize"),
+            token_endpoint: format!("{base}/token"),
+            jwks_uri: format!("{base}/jwks"),
+        }
+    }
+
+    fn test_oidc_config(base: &str) -> crate::config::OidcConfig {
+        crate::config::OidcConfig {
+            endpoint: base.to_string(),
+            client_id: "test-client".into(),
+            client_secret: "test-secret".into(),
+            scopes: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn exchange_code_captures_the_refresh_token() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=authorization_code"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id_token": "header.payload.sig",
+                "refresh_token": "refresh-123",
+            })))
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let tokens = exchange_code(
+            &http,
+            &test_oidc_config(&server.uri()),
+            &mock_discovery(&server.uri()),
+            "auth-code",
+            "verifier",
+            "http://localhost/api/v1/auth/callback",
+        )
+        .await
+        .unwrap();
+        assert_eq!(tokens.id_token, "header.payload.sig");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("refresh-123"));
+    }
+
+    #[tokio::test]
+    async fn refresh_reuses_the_old_token_when_the_provider_does_not_rotate() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id_token": "renewed.id.token",
+            })))
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let tokens = refresh_tokens(
+            &http,
+            &test_oidc_config(&server.uri()),
+            &mock_discovery(&server.uri()),
+            "refresh-123",
+        )
+        .await
+        .unwrap();
+        assert_eq!(tokens.id_token, "renewed.id.token");
+        assert_eq!(
+            tokens.refresh_token.as_deref(),
+            Some("refresh-123"),
+            "a non-rotating provider's response must not discard the caller's refresh token"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_adopts_a_rotated_token_and_surfaces_rejections() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("refresh_token=live-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id_token": "renewed.id.token",
+                "refresh_token": "rotated-456",
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("refresh_token=revoked-token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "invalid_grant",
+            })))
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let oidc = test_oidc_config(&server.uri());
+        let discovery = mock_discovery(&server.uri());
+
+        let tokens = refresh_tokens(&http, &oidc, &discovery, "live-token")
+            .await
+            .unwrap();
+        assert_eq!(tokens.refresh_token.as_deref(), Some("rotated-456"));
+
+        assert!(
+            refresh_tokens(&http, &oidc, &discovery, "revoked-token")
+                .await
+                .is_err(),
+            "a rejected grant must surface as an error so the session is dropped"
+        );
     }
 
     #[test]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,7 +20,10 @@ web:
     #   endpoint: "https://idp.example.com"
     #   client_id: "analytics-dashboard"
     #   client_secret: "${{ env.OIDC_CLIENT_SECRET }}"
-    #   scopes: ["profile", "email", "groups"]
+    #   # Include "offline_access" (where your provider supports/requires it) so a
+    #   # refresh token is issued and sessions renew silently instead of ending
+    #   # when the ID token expires.
+    #   scopes: ["profile", "email", "groups", "offline_access"]
 
 storage:
   redb_path: "analytics.redb"

--- a/ui/Cargo.lock
+++ b/ui/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "chrono",
  "console_error_panic_hook",
  "filt-rs",
+ "futures",
  "gloo-net",
  "gloo-utils",
  "js-sys",
@@ -169,6 +170,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -190,6 +192,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -30,6 +30,10 @@ yew-router = "0.20"
 gloo-net = "0.5"
 gloo-utils = "0.2"
 
+# Shared futures so concurrent 401-driven session refreshes coalesce onto a
+# single renewal (see `auth::refresh_session`).
+futures = "0.3"
+
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -3,7 +3,9 @@
 //! Auth relies on the agent's `HttpOnly` session cookie (sent automatically on
 //! same-origin requests); the UI never sees a token. Mutating requests carry a
 //! double-submit CSRF token in `X-CSRF-Token`, fetched once and cached. A `401`
-//! surfaces as [`ApiError::Unauthorized`] so callers can redirect to login.
+//! first triggers a transparent session renewal ([`crate::auth::refresh_session`])
+//! and a single retry; only when the session truly cannot be renewed does it
+//! surface as [`ApiError::Unauthorized`] so callers can redirect to login.
 
 use std::cell::RefCell;
 
@@ -66,10 +68,8 @@ fn cached_csrf() -> Option<String> {
 }
 
 async fn fetch_csrf() -> Result<String, ApiError> {
-    let resp = Request::get(&format!("{API_BASE}/csrf"))
-        .send()
-        .await
-        .map_err(net)?;
+    let url = format!("{API_BASE}/csrf");
+    let resp = send_with_session(|| Request::get(&url).build()).await?;
     if !resp.ok() {
         return Err(error_from(resp).await);
     }
@@ -89,11 +89,28 @@ fn invalidate_csrf() {
     CSRF_TOKEN.with(|t| *t.borrow_mut() = None);
 }
 
+/// Send a request, transparently renewing the session and retrying once when the
+/// server rejects it with a `401` (the session cookie lapsed, but the agent may
+/// hold a refresh token it can redeem). The renewal is coalesced across
+/// concurrent callers, so a page's parallel fetches failing together produce a
+/// single refresh. When renewal fails the original `401` is returned untouched.
+async fn send_with_session<F>(build: F) -> Result<gloo_net::http::Response, ApiError>
+where
+    F: Fn() -> Result<Request, gloo_net::Error>,
+{
+    let resp = build().map_err(net)?.send().await.map_err(net)?;
+    if resp.status() != 401 {
+        return Ok(resp);
+    }
+    if crate::auth::refresh_session().await.is_err() {
+        return Ok(resp);
+    }
+    build().map_err(net)?.send().await.map_err(net)
+}
+
 async fn get_json<T: DeserializeOwned>(path: &str) -> Result<T, ApiError> {
-    let resp = Request::get(&format!("{API_BASE}{path}"))
-        .send()
-        .await
-        .map_err(net)?;
+    let url = format!("{API_BASE}{path}");
+    let resp = send_with_session(|| Request::get(&url).build()).await?;
     if !resp.ok() {
         return Err(error_from(resp).await);
     }
@@ -108,7 +125,7 @@ where
     let mut refreshed = false;
     loop {
         let token = ensure_csrf().await?;
-        let resp = build(&token).map_err(net)?.send().await.map_err(net)?;
+        let resp = send_with_session(|| build(&token)).await?;
         if resp.ok() {
             return Ok(resp);
         }
@@ -153,10 +170,8 @@ fn enc(value: &str) -> String {
 // ------------------------------------------------------------------ endpoints
 
 pub async fn me() -> Result<Option<AdminUser>, ApiError> {
-    let resp = Request::get(&format!("{API_BASE}/me"))
-        .send()
-        .await
-        .map_err(net)?;
+    let url = format!("{API_BASE}/me");
+    let resp = send_with_session(|| Request::get(&url).build()).await?;
     if resp.status() == 204 {
         return Ok(None);
     }

--- a/ui/src/auth.rs
+++ b/ui/src/auth.rs
@@ -1,8 +1,118 @@
 //! Browser-side helpers for the server-driven OIDC session. Signing in is a
 //! full-page navigation to the agent's login endpoint; the browser never handles
-//! tokens.
+//! tokens. When the session's ID token lapses the agent can renew it from an
+//! `HttpOnly` refresh-token cookie, so [`refresh_session`] just POSTs to the
+//! renewal endpoint and the browser picks up the re-issued cookies.
+
+use futures::FutureExt;
 
 use crate::api;
+use single_flight::SingleFlight;
+
+/// A single-flight coordinator: it collapses concurrent runs of an async
+/// operation onto one shared execution so the operation runs at most once at a
+/// time, no matter how many callers ask for it together (see [`refresh_session`]
+/// for why that matters). Ported from SierraSoftworks/grey. Browser-only — it
+/// stores its state in an `Rc`/`RefCell`, so it lives behind a `thread_local`
+/// rather than a lock.
+mod single_flight {
+    use std::cell::{Cell, RefCell};
+    use std::future::Future;
+    use std::rc::Rc;
+
+    use futures::FutureExt;
+    use futures::future::{LocalBoxFuture, Shared};
+
+    struct Inner<T: Clone> {
+        /// The run currently in flight, tagged with the generation that started
+        /// it; cloned for every caller that joins it and cleared once it settles,
+        /// so the next call starts a fresh run.
+        current: RefCell<Option<(u64, Shared<LocalBoxFuture<'static, T>>)>>,
+        generation: Cell<u64>,
+    }
+
+    pub struct SingleFlight<T: Clone> {
+        inner: Rc<Inner<T>>,
+    }
+
+    impl<T: Clone + 'static> SingleFlight<T> {
+        pub fn new() -> Self {
+            Self {
+                inner: Rc::new(Inner {
+                    current: RefCell::new(None),
+                    generation: Cell::new(0),
+                }),
+            }
+        }
+
+        /// Run the future produced by `start`, unless a run begun by an earlier,
+        /// still-unsettled call is already in flight — in which case that one is
+        /// joined instead and `start` is never invoked. The returned future is
+        /// self-contained (it owns a handle to the shared state), so it can be
+        /// awaited outside the borrow that produced it.
+        pub fn run<F>(&self, start: F) -> impl Future<Output = T> + use<F, T>
+        where
+            F: FnOnce() -> LocalBoxFuture<'static, T>,
+        {
+            let inner = self.inner.clone();
+            async move {
+                let (generation, shared) = {
+                    let mut current = inner.current.borrow_mut();
+                    if let Some((generation, existing)) = current.as_ref() {
+                        (*generation, existing.clone())
+                    } else {
+                        let generation = inner.generation.get().wrapping_add(1);
+                        inner.generation.set(generation);
+                        let shared = start().shared();
+                        *current = Some((generation, shared.clone()));
+                        (generation, shared)
+                    }
+                };
+
+                let result = shared.await;
+
+                // Retire this run so the next call starts afresh, but only if a
+                // later run hasn't already replaced it — otherwise we'd strand
+                // the newer one and let a second concurrent run start.
+                let mut current = inner.current.borrow_mut();
+                if matches!(current.as_ref(), Some((g, _)) if *g == generation) {
+                    *current = None;
+                }
+                result
+            }
+        }
+    }
+}
+
+thread_local! {
+    /// Coalesces concurrent, 401-driven renewals onto a single redemption of the
+    /// refresh token (see [`refresh_session`]).
+    static REFRESH: SingleFlight<Result<(), ()>> = SingleFlight::new();
+}
+
+/// Renew the server-held session from its refresh-token cookie.
+///
+/// Concurrent callers are coalesced onto a single renewal: the first starts the
+/// refresh and the rest await its result. This matters because providers may
+/// *rotate* the refresh token — each redemption can invalidate the token it used.
+/// Several requests routinely fail together (a page's parallel fetches all hit a
+/// 401 the moment the ID token lapses); were each to redeem the refresh token
+/// independently, only the first would succeed and the losers would kill the
+/// freshly renewed session. `Ok` means the agent re-issued the session cookie and
+/// the failed request can be retried.
+pub async fn refresh_session() -> Result<(), ()> {
+    REFRESH
+        .with(|flight| flight.run(|| do_refresh_session().boxed_local()))
+        .await
+}
+
+async fn do_refresh_session() -> Result<(), ()> {
+    let response = gloo_net::http::Request::post("/api/v1/auth/refresh")
+        .send()
+        .await
+        .map_err(|_| ())?;
+    if response.ok() { Ok(()) } else { Err(()) }
+}
 
 fn window() -> web_sys::Window {
     web_sys::window().expect("a browser window should be available")


### PR DESCRIPTION
# Summary

The dashboard was forgetting the signed-in state every time the access token needed refreshing: the `analytics_session` cookie holds the OIDC ID token and its max-age is tied to the token's `exp` claim, so the session lived exactly as long as the ID token (often minutes to an hour), and the first `401` dropped the operator back to the sign-in screen with no renewal ever attempted.

This PR reviews how the Grey and Automate UIs manage session state and token renewal, and ports the working model into Analytics:

- **Automate** (which this agent's auth flow was originally ported from) has the *same* limitation — its code exchange deserialises only the `id_token` and discards any refresh token, with no renewal path at all.
- **Grey** has the functionality we want: the server-side code exchange captures the provider's **refresh token**, the agent exposes a renewal endpoint that redeems it via the `refresh_token` grant, and the SPA reacts to any `401` by performing a **single-flight coalesced refresh** and retrying the request once — keeping "who is signed in" stable across token renewals.

Grey's flow is adapted here to Analytics' server-driven cookie architecture (the browser never handles tokens, unlike Grey's `sessionStorage` model).

## Agent

- `exchange_code` now returns a `TokenSet` and captures the provider's `refresh_token` alongside the `id_token` (`agent/src/web/helpers/oidc.rs`).
- New `refresh_tokens` helper performs the `grant_type=refresh_token` exchange with the server-held client secret, carrying the caller's refresh token over when the provider doesn't rotate it (mirroring Grey's `OidcVerifier::refresh_tokens`).
- The callback stores the refresh token in a new `analytics_refresh` cookie: `HttpOnly`, `SameSite=Lax`, scoped to `/api/v1/auth` so it never travels with ordinary API requests, with a 30-day browser-side cap (the provider stays the authority on whether the token is still redeemable).
- New `POST /api/v1/auth/refresh` endpoint redeems that cookie, validates the fresh ID token, and re-issues the session cookie (plus the rotated refresh token when one is supplied). It needs no CSRF check: the `SameSite=Lax` cookie never accompanies a forged cross-site `POST`. A rejected grant clears both cookies (the session is truly over); a provider outage returns `502` and keeps them so renewal can be retried.
- Logout clears the refresh cookie alongside the session cookie.

## UI

- All API requests (`get_json`, `me`, `fetch_csrf`, and mutations) now flow through a choke point that reacts to a `401` by renewing the session and retrying once; only when renewal fails does `ApiError::Unauthorized` surface and return the user to sign-in. Because `me()` renews transparently too, a page load after ID-token expiry silently restores the session instead of demanding a fresh login.
- Concurrent renewals coalesce onto a single redemption via Grey's `SingleFlight` combinator (ported): providers may rotate refresh tokens on use, so when a page's parallel fetches all hit `401` together, letting each redeem the token independently would invalidate the freshly minted session.

## Configuration

Providers generally only issue refresh tokens when asked — `config.example.yaml` now shows `offline_access` in the example scopes. Without a refresh token everything behaves exactly as before, so this is fully backwards-compatible.

## Testing

- `cargo test` — 86 tests pass, including three new `wiremock`-backed tests covering: capturing the refresh token during the code exchange, retaining the old refresh token when the provider doesn't rotate, adopting a rotated token, and surfacing rejected grants as errors.
- `cargo check`/`cargo build --release` for `wasm32-unknown-unknown` on the UI crate — clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HHTAFFmQKN12o5nbsPbnS

---
_Generated by [Claude Code](https://claude.ai/code/session_015HHTAFFmQKN12o5nbsPbnS)_