### PR TITLE
Present versions as app @ version and browsers as Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ deliberately collects only broad, non-identifying signals:
 - **Projects & sources** — group multiple hostnames (and applications) into a
   project; filter to subsets; auto-register new reporting hostnames.
 - **Metrics** — visitors, page views, bounce rate, median time on page, time
-  series, and breakdowns by page, referrer, browser, OS, device, country,
-  language, and source.
+  series, and breakdowns by page, referrer, application (browser or client
+  app) and its version, OS, device, country, language, and source.
 - **Tracking pixels** — admin-created, project-bound tracking GIFs (e.g. for email
   opens) with attached metadata. Unknown pixel ids are rejected — there is no open
   pixel endpoint.

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use analytics_api::{
     BreakdownRow, Breakdowns, CountRow, Dashboard, ExceptionBreakdowns, ExceptionGroup,
     ExceptionGroupDetail, ExceptionStatus, ExceptionVariant, MetricSummary, TREND_BUCKETS,
-    TimeSeriesPoint, pixel_source,
+    TimeSeriesPoint, VersionRow, pixel_source, source_label,
 };
 use chrono::{Datelike, TimeZone, Utc};
 use polars::prelude::*;
@@ -99,7 +99,7 @@ pub fn dashboard(
             countries: breakdown(pageloads.clone(), "country", unique_flag)?,
             languages: breakdown(pageloads.clone(), "language", unique_flag)?,
             browsers: breakdown(pageloads.clone(), "ua_browser", unique_flag)?,
-            versions: breakdown(pageloads.clone(), "ua_version", unique_flag)?,
+            versions: version_breakdown(pageloads.clone(), unique_flag)?,
             operating_systems: breakdown(pageloads.clone(), "ua_os", unique_flag)?,
             devices: breakdown(pageloads.clone(), "ua_device", unique_flag)?,
             utm_sources: breakdown(pageloads.clone(), "utm_source", unique_flag)?,
@@ -315,7 +315,7 @@ pub fn exception_detail(
     };
 
     let breakdowns = ExceptionBreakdowns {
-        app_versions: count_by(&df, "app_version")?,
+        app_versions: app_version_rows(&df)?,
         browsers: count_by(&df, "ua_browser")?,
         operating_systems: count_by(&df, "ua_os")?,
         devices: count_by(&df, "ua_device")?,
@@ -365,6 +365,62 @@ fn count_by(occurrences: &DataFrame, column: &str) -> Result<Vec<CountRow>> {
             })
         })
         .collect())
+}
+
+/// Occurrence counts per reported release, keyed as `app @ version` (the app
+/// being the source's label) — a release number is only meaningful within its
+/// application. Occurrences with no reported version aggregate under the
+/// empty sentinel, whichever source they came from.
+fn app_version_rows(occurrences: &DataFrame) -> Result<Vec<CountRow>> {
+    let df = occurrences
+        .clone()
+        .lazy()
+        .with_columns([
+            col("source").fill_null(lit("")).alias("app"),
+            col("app_version").fill_null(lit("")).alias("version"),
+        ])
+        .group_by([col("app"), col("version")])
+        .agg([len().cast(DataType::Int64).alias("count")])
+        .collect()
+        .or_system_err(ADVICE)?;
+
+    let apps = df
+        .column("app")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let versions = df
+        .column("version")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let counts = df
+        .column("count")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+
+    // Distinct sources can share a label (http vs https), so fold by the
+    // display key rather than trusting the group-by to have finished the job.
+    let mut totals: HashMap<String, i64> = HashMap::new();
+    for i in 0..df.height() {
+        let (Some(app), Some(version)) = (apps.get(i), versions.get(i)) else {
+            continue;
+        };
+        let key = match (app.is_empty(), version.is_empty()) {
+            (_, true) => String::new(),
+            (true, false) => version.to_string(),
+            (false, false) => format!("{} @ {version}", source_label(app)),
+        };
+        *totals.entry(key).or_insert(0) += counts.get(i).unwrap_or(0);
+    }
+    let mut rows: Vec<CountRow> = totals
+        .into_iter()
+        .map(|(key, count)| CountRow { key, count })
+        .collect();
+    rows.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.key.cmp(&b.key)));
+    rows.truncate(BREAKDOWN_LIMIT as usize);
+    Ok(rows)
 }
 
 /// Collapse a group's occurrences (already sorted newest-first) into distinct
@@ -786,6 +842,67 @@ fn breakdown(pageloads: LazyFrame, column: &str, unique_flag: &str) -> Result<Ve
         .collect())
 }
 
+/// The client-versions breakdown over the page-load frame, keyed by the
+/// (application, version) pair — a version number is only meaningful within
+/// its application, so "120.0" from Chrome and "120.0" from Edge stay separate
+/// rows. Nulls aggregate under the empty-string sentinel like every other
+/// breakdown.
+fn version_breakdown(pageloads: LazyFrame, unique_flag: &str) -> Result<Vec<VersionRow>> {
+    let df = pageloads
+        .with_columns([
+            col("ua_browser").fill_null(lit("")).alias("app"),
+            col("ua_version").fill_null(lit("")).alias("version"),
+        ])
+        .group_by([col("app"), col("version")])
+        .agg([
+            len().cast(DataType::Int64).alias("pageviews"),
+            col(unique_flag)
+                .sum()
+                .cast(DataType::Int64)
+                .alias("visitors"),
+        ])
+        .sort(
+            ["pageviews"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
+        .limit(BREAKDOWN_LIMIT)
+        .collect()
+        .or_system_err(ADVICE)?;
+
+    let apps = df
+        .column("app")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let versions = df
+        .column("version")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let pageviews = df
+        .column("pageviews")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let visitors = df
+        .column("visitors")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+
+    Ok((0..df.height())
+        .filter_map(|i| {
+            Some(VersionRow {
+                app: apps.get(i)?.to_string(),
+                version: versions.get(i)?.to_string(),
+                pageviews: pageviews.get(i).unwrap_or(0),
+                visitors: visitors.get(i).unwrap_or(0),
+                events: 0,
+            })
+        })
+        .collect())
+}
+
 /// Per-source totals. Page loads count as `pageviews`; pixel hits and custom
 /// events count as `events` so pixel-only and application sources still surface;
 /// `visitors` uses the same daily-unique flag as every other aggregation in the
@@ -1043,8 +1160,11 @@ mod tests {
         );
         assert_eq!(dash.breakdowns.pages.first().map(|p| p.pageviews), Some(3));
         assert_eq!(
-            dash.breakdowns.versions.first().map(|v| v.key.as_str()),
-            Some("120.0")
+            dash.breakdowns
+                .versions
+                .first()
+                .map(|v| (v.app.as_str(), v.version.as_str())),
+            Some(("Chrome", "120.0"))
         );
 
         drop(store);
@@ -1487,14 +1607,19 @@ mod tests {
             Some(r#"{"feature_flag":"checkout-v2"}"#)
         );
 
-        // Distributions cover app versions (1.1.0 twice, 1.0.0 once), and the
-        // sources card doubles as the per-application distribution.
+        // Distributions cover app releases (1.1.0 twice, 1.0.0 once), keyed as
+        // `app @ version` since a release is only meaningful within its app;
+        // the sources card doubles as the per-application distribution.
         let versions = &detail.breakdowns.app_versions;
         assert_eq!(
             versions.first().map(|r| (r.key.as_str(), r.count)),
-            Some(("1.1.0", 2))
+            Some(("a.com @ 1.1.0", 2))
         );
-        assert!(versions.iter().any(|r| r.key == "1.0.0" && r.count == 1));
+        assert!(
+            versions
+                .iter()
+                .any(|r| r.key == "a.com @ 1.0.0" && r.count == 1)
+        );
         assert_eq!(
             detail
                 .breakdowns

--- a/api/src/exception.rs
+++ b/api/src/exception.rs
@@ -100,6 +100,9 @@ pub struct ExceptionVariant {
 /// by source, so the sources distribution *is* the per-app distribution.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ExceptionBreakdowns {
+    /// Reported releases, keyed as `app @ version` (the app being the source's
+    /// label) since a release number is only meaningful within its application.
+    /// Versionless occurrences aggregate under the empty sentinel.
     pub app_versions: Vec<crate::CountRow>,
     pub browsers: Vec<crate::CountRow>,
     pub operating_systems: Vec<crate::CountRow>,

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -29,5 +29,6 @@ pub use source::{
 };
 pub use stats::{
     BreakdownRow, Breakdowns, CountRow, Dashboard, DashboardQuery, MetricSummary, TimeSeriesPoint,
+    VersionRow,
 };
 pub use track::{BeaconKind, TrackEvent};

--- a/api/src/stats.rs
+++ b/api/src/stats.rs
@@ -94,6 +94,22 @@ pub struct BreakdownRow {
     pub events: i64,
 }
 
+/// One row of the client-versions breakdown. A version number is only
+/// meaningful within its application ("120.0" from Chrome and "120.0" from
+/// Edge are unrelated), so rows are keyed by the (application, version) pair
+/// rather than the bare version string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionRow {
+    /// The UA-derived application (browser or client app) name; empty when unknown.
+    pub app: String,
+    /// The version within that application; empty when unknown.
+    pub version: String,
+    pub visitors: i64,
+    pub pageviews: i64,
+    #[serde(default)]
+    pub events: i64,
+}
+
 /// Every dashboard breakdown, computed over the same filtered event set so the
 /// panels agree with the headline metrics and with each other.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -102,11 +118,12 @@ pub struct Breakdowns {
     pub referrers: Vec<BreakdownRow>,
     pub countries: Vec<BreakdownRow>,
     pub languages: Vec<BreakdownRow>,
+    /// UA-derived applications: browsers and client apps alike.
     pub browsers: Vec<BreakdownRow>,
-    /// UA-derived client versions (browser or application). `serde(default)`
-    /// tolerates payloads from agents predating the column.
+    /// UA-derived client versions, one row per (application, version) pair.
+    /// `serde(default)` tolerates payloads from agents predating the column.
     #[serde(default)]
-    pub versions: Vec<BreakdownRow>,
+    pub versions: Vec<VersionRow>,
     pub operating_systems: Vec<BreakdownRow>,
     pub devices: Vec<BreakdownRow>,
     pub utm_sources: Vec<BreakdownRow>,

--- a/ui/src/components/breakdown.rs
+++ b/ui/src/components/breakdown.rs
@@ -24,6 +24,9 @@ pub struct PanelRow {
     pub events: i64,
     /// Hovering the label shows this (defaults to the label).
     pub title: Option<String>,
+    /// An additional filter term applied (and toggled) together with the
+    /// row's main value — e.g. a version row also pins its application.
+    pub extra: Option<(Dim, String)>,
 }
 
 impl PanelRow {
@@ -70,8 +73,9 @@ impl PanelTab {
 pub struct BreakdownPanelProps {
     pub tabs: Vec<PanelTab>,
     pub metric: Metric,
-    /// Invoked with `(dim, raw value)` when a row is clicked.
-    pub on_filter: Callback<(Dim, String)>,
+    /// Invoked with the row's filter terms — `(dim, raw value)` pairs, the
+    /// tab's dimension first — when a row is clicked.
+    pub on_filter: Callback<Vec<(Dim, String)>>,
     /// The active filter value per dimension (highlights the selected row).
     #[prop_or_default]
     pub active: Vec<(Dim, String)>,
@@ -130,12 +134,16 @@ pub fn breakdown_panel(props: &BreakdownPanelProps) -> Html {
         let value = row.value_for(metric);
         let share = if total > 0 { value as f64 / total as f64 * 100.0 } else { 0.0 };
         let bar = if max > 0 { value as f64 / max as f64 * 100.0 } else { 0.0 };
-        let is_selected = selected == Some(row.value.as_str());
+        let is_selected = selected == Some(row.value.as_str())
+            && row.extra.as_ref().is_none_or(|(dim, value)| {
+                props.active.iter().any(|(d, v)| d == dim && v == value)
+            });
 
         let onclick = {
             let on_filter = props.on_filter.clone();
-            let (dim, value) = (tab.dim, row.value.clone());
-            Callback::from(move |_: MouseEvent| on_filter.emit((dim, value.clone())))
+            let mut terms = vec![(tab.dim, row.value.clone())];
+            terms.extend(row.extra.clone());
+            Callback::from(move |_: MouseEvent| on_filter.emit(terms.clone()))
         };
         // The action is a sibling of the row button (never a child — nested
         // interactive elements are invalid HTML and confuse assistive tech),

--- a/ui/src/filters.rs
+++ b/ui/src/filters.rs
@@ -100,7 +100,10 @@ impl Dim {
             Dim::Referrer => "Referrer",
             Dim::Country => "Country",
             Dim::Language => "Language",
-            Dim::Browser => "Browser",
+            // Client-side apps report alongside browsers, so the UA-client
+            // dimension is presented as "Application" (the `browser` query
+            // field is kept for expression compatibility).
+            Dim::Browser => "Application",
             Dim::Version => "Version",
             Dim::Os => "OS",
             Dim::Device => "Device",

--- a/ui/src/pages/dashboard.rs
+++ b/ui/src/pages/dashboard.rs
@@ -60,16 +60,24 @@ pub fn dashboard() -> Html {
         });
     }
 
-    // Toggle semantics: clicking a row that is already the active filter for
-    // its dimension clears that filter instead of re-applying it.
+    // Toggle semantics: clicking a row whose terms (most rows carry one; a
+    // version row also pins its application) are all already active clears
+    // them instead of re-applying them.
     let on_filter = {
         let (apply, filters) = (apply.clone(), filters.clone());
-        Callback::from(move |(dim, value): (Dim, String)| {
-            if filters.get(dim) == Some(value.as_str()) {
-                apply.emit(filters.without(dim));
-            } else {
-                apply.emit(filters.with(dim, value));
+        Callback::from(move |terms: Vec<(Dim, String)>| {
+            let active = terms
+                .iter()
+                .all(|(dim, value)| filters.get(*dim) == Some(value.as_str()));
+            let mut next = filters.clone();
+            for (dim, value) in terms {
+                next = if active {
+                    next.without(dim)
+                } else {
+                    next.with(dim, value)
+                };
             }
+            apply.emit(next);
         })
     };
 
@@ -154,9 +162,27 @@ pub fn dashboard() -> Html {
                         pageviews: r.pageviews,
                         events: r.events,
                         title: (!r.key.is_empty()).then(|| r.key.clone()),
+                        extra: None,
                     })
                     .collect()
             };
+            let versions = dash
+                .breakdowns
+                .versions
+                .iter()
+                .map(|r| PanelRow {
+                    value: r.version.clone(),
+                    label: version_label(r),
+                    icon: None,
+                    visitors: r.visitors,
+                    pageviews: r.pageviews,
+                    events: r.events,
+                    title: (!r.app.is_empty() || !r.version.is_empty()).then(|| version_label(r)),
+                    // The version alone would also match other applications'
+                    // releases, so clicking pins the application with it.
+                    extra: Some((Dim::Browser, r.app.clone())),
+                })
+                .collect::<Vec<_>>();
             let countries = dash
                 .breakdowns
                 .countries
@@ -173,6 +199,7 @@ pub fn dashboard() -> Html {
                     pageviews: r.pageviews,
                     events: r.events,
                     title: None,
+                    extra: None,
                 })
                 .collect::<Vec<_>>();
             let languages = dash
@@ -191,6 +218,7 @@ pub fn dashboard() -> Html {
                     pageviews: r.pageviews,
                     events: r.events,
                     title: (!r.key.is_empty()).then(|| r.key.clone()),
+                    extra: None,
                 })
                 .collect::<Vec<_>>();
             let project_rows = dash
@@ -205,6 +233,7 @@ pub fn dashboard() -> Html {
                     pageviews: r.pageviews,
                     events: r.events,
                     title: None,
+                    extra: None,
                 })
                 .collect::<Vec<_>>();
             let source_rows = dash
@@ -219,6 +248,7 @@ pub fn dashboard() -> Html {
                     pageviews: r.pageviews,
                     events: r.events,
                     title: Some(r.key.clone()),
+                    extra: None,
                 })
                 .collect::<Vec<_>>();
 
@@ -259,15 +289,11 @@ pub fn dashboard() -> Html {
             ];
             let platform_tabs = vec![
                 PanelTab::new(
-                    "Browsers",
+                    "Applications",
                     Dim::Browser,
                     plain(&dash.breakdowns.browsers, "Unknown"),
                 ),
-                PanelTab::new(
-                    "Versions",
-                    Dim::Version,
-                    plain(&dash.breakdowns.versions, "Unknown"),
-                ),
+                PanelTab::new("Versions", Dim::Version, versions),
                 PanelTab::new(
                     "OS",
                     Dim::Os,
@@ -446,7 +472,17 @@ fn build_suggestions(
                 .collect(),
         ),
         (Dim::Browser, rows(&dash.breakdowns.browsers, "Unknown")),
-        (Dim::Version, rows(&dash.breakdowns.versions, "Unknown")),
+        (
+            Dim::Version,
+            dash.breakdowns
+                .versions
+                .iter()
+                .map(|r| SuggestOption {
+                    value: r.version.clone(),
+                    label: version_label(r),
+                })
+                .collect(),
+        ),
         (Dim::Os, rows(&dash.breakdowns.operating_systems, "Unknown")),
         (Dim::Device, rows(&dash.breakdowns.devices, "Unknown")),
         (Dim::UtmSource, rows(&dash.breakdowns.utm_sources, "None")),
@@ -456,6 +492,18 @@ fn build_suggestions(
             rows(&dash.breakdowns.utm_campaigns, "None"),
         ),
     ]
+}
+
+/// The display form of a client-version row: qualified by its application,
+/// since a bare version number is meaningless across applications. Falls back
+/// to whichever half is known when the other is absent.
+fn version_label(row: &analytics_api::VersionRow) -> String {
+    match (row.app.is_empty(), row.version.is_empty()) {
+        (false, false) => format!("{} @ {}", row.app, row.version),
+        (false, true) => row.app.clone(),
+        (true, false) => row.version.clone(),
+        (true, true) => "Unknown".to_string(),
+    }
 }
 
 #[derive(Properties, PartialEq)]

--- a/ui/src/pages/exception_detail.rs
+++ b/ui/src/pages/exception_detail.rs
@@ -1,6 +1,6 @@
 //! One exception group in forensic detail: triage controls, the occurrence
 //! trend, how failures distribute across key dimensions (app version, OS,
-//! browser, …), and a scrubber over the group's **distinct variants** — one
+//! application, …), and a scrubber over the group's **distinct variants** — one
 //! representative example per unique message/stack, with a count of the
 //! occurrences it stands for.
 
@@ -119,7 +119,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
                             <div class="dist-grid">
                                 { distribution("App versions", &detail.breakdowns.app_versions, detail.group.count) }
                                 { distribution("Apps / sources", &detail.breakdowns.sources, detail.group.count) }
-                                { distribution("Browsers", &detail.breakdowns.browsers, detail.group.count) }
+                                { distribution("Applications", &detail.breakdowns.browsers, detail.group.count) }
                                 { distribution("Operating systems", &detail.breakdowns.operating_systems, detail.group.count) }
                                 { distribution("Devices", &detail.breakdowns.devices, detail.group.count) }
                             </div>


### PR DESCRIPTION
A version number is only meaningful within the context of the application that reported it, and the UA-client dimension covers client-side apps alongside browsers — so the web UI now presents both accordingly.

## Changes

**Versions are presented as `app @ version`**
- The dashboard's client-version breakdown is now computed per `(ua_browser, ua_version)` pair instead of the bare version string, carried by a new `VersionRow { app, version, … }` API type. "120.0" from Chrome and "120.0" from Edge no longer collapse into one ambiguous row.
- Version rows render as `Chrome @ 120.0` in the Versions tab and the add-filter suggestions. When only one half is known, that half is shown alone; fully unknown rows keep the "Unknown" sentinel.
- Clicking a version row now pins the application together with the version (two chips: `Application: Chrome`, `Version: 120.0`), since the version alone would also match other applications' releases. `PanelRow` gained an optional extra filter term to support this, and row-toggle/selection semantics account for both terms.
- The exception detail's "App versions" distribution is keyed the same way (`a.com @ 1.1.0`), with the app being the reporting source's label; versionless occurrences still aggregate under the "Unknown" sentinel.

**Browsers are referred to as Applications**
- The dashboard platform tab, the `Application` filter-chip/add-filter label, and the exception detail distribution card are all renamed. The `browser` field in the query language is unchanged, so existing filter expressions and shared URLs keep working.

## Notes

- `Breakdowns.versions` keeps its `#[serde(default)]`, so payloads from agents predating the column still deserialize.
- Agent tests updated to assert the new row shapes; full workspace test suite passes and the UI type-checks for `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4YhAxoEUEfBChHHx5Uavo

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4YhAxoEUEfBChHHx5Uavo)_