### PR TITLE
Filter projects by their unique name instead of their id

### DIFF
--- a/agent/src/analytics/filter.rs
+++ b/agent/src/analytics/filter.rs
@@ -150,7 +150,7 @@ impl Node {
                 .and(col(field.column).neq(lit("")))),
             Node::Column(field) => Ok(col(field.column).fill_null(lit(false))),
             Node::Bool(value) => Ok(lit(value)),
-            Node::Project => Err("`project` must be compared, e.g. project == \"<id>\"".into()),
+            Node::Project => Err("`project` must be compared, e.g. project == \"<name>\"".into()),
             Node::Str(_) | Node::List(_) | Node::Null => {
                 Err("this value cannot be used as a condition on its own".into())
             }
@@ -179,16 +179,18 @@ struct Compiler<'s> {
 }
 
 impl Compiler<'_> {
-    /// The source URIs belonging to a project (empty for unknown ids, which
-    /// then matches nothing — never everything).
-    fn project_sources(&self, project_id: &str) -> Vec<String> {
-        super::project_source_uris(self.store, project_id).unwrap_or_default()
+    /// The source URIs belonging to a project, looked up by its (unique) name —
+    /// case-insensitively, like every other string comparison in the language —
+    /// with an id fallback for pre-rename links. Empty for unknown values, which
+    /// then match nothing — never everything.
+    fn project_sources(&self, project: &str) -> Vec<String> {
+        super::project_source_uris_by_name(self.store, project).unwrap_or_default()
     }
 
-    fn source_membership(&self, project_ids: &[String]) -> Expr {
-        let uris: Vec<String> = project_ids
+    fn source_membership(&self, projects: &[String]) -> Expr {
+        let uris: Vec<String> = projects
             .iter()
-            .flat_map(|id| self.project_sources(id))
+            .flat_map(|name| self.project_sources(name))
             .collect();
         col("source").is_in(lit(Series::new("sources".into(), uris)), false)
     }
@@ -306,14 +308,14 @@ impl<'a> ExprVisitor<'a, Fold> for Compiler<'_> {
 
         match (&subject, operator, &object) {
             // ---- project membership --------------------------------------
-            (Node::Project, Equals, Node::Str(id)) => Ok(Node::Predicate(
-                self.source_membership(std::slice::from_ref(id)),
+            (Node::Project, Equals, Node::Str(name)) => Ok(Node::Predicate(
+                self.source_membership(std::slice::from_ref(name)),
             )),
-            (Node::Project, NotEquals, Node::Str(id)) => Ok(Node::Predicate(
-                self.source_membership(std::slice::from_ref(id)).not(),
+            (Node::Project, NotEquals, Node::Str(name)) => Ok(Node::Predicate(
+                self.source_membership(std::slice::from_ref(name)).not(),
             )),
-            (Node::Project, In | InCs, Node::List(ids)) => {
-                Ok(Node::Predicate(self.source_membership(ids)))
+            (Node::Project, In | InCs, Node::List(names)) => {
+                Ok(Node::Predicate(self.source_membership(names)))
             }
 
             // ---- equality --------------------------------------------------
@@ -550,7 +552,7 @@ mod tests {
             r#"path like "/docs/*""#,
             r#"!(browser == "Safari")"#,
             r#"referrer == """#,
-            r#"project == "some-project-id""#,
+            r#"project == "Some Project""#,
             "browser", // truthy: browser is present
         ] {
             assert!(compiles(q), "expected `{q}` to compile");

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -112,6 +112,24 @@ pub fn dashboard(
     })
 }
 
+/// The source URIs belonging to the project whose **name** matches `name`
+/// (case-insensitively, matching the filter language's string semantics; names
+/// are unique). Values that name no project fall back to an id lookup, so
+/// pre-rename links that filtered by project id keep working. An unknown value
+/// resolves to no sources, so the filter matches nothing — never everything.
+pub fn project_source_uris_by_name(store: &Store, name: &str) -> Result<Vec<String>> {
+    let projects = store.list_projects()?;
+    let needle = name.to_lowercase();
+    let project = projects
+        .iter()
+        .find(|p| p.name.to_lowercase() == needle)
+        .or_else(|| projects.iter().find(|p| p.id == name));
+    match project {
+        Some(project) => project_source_uris(store, &project.id),
+        None => Ok(Vec::new()),
+    }
+}
+
 /// The source URIs belonging to a project: its assigned sources plus its pixels
 /// (as `pixel://<id>` URIs).
 pub fn project_source_uris(store: &Store, project_id: &str) -> Result<Vec<String>> {
@@ -1295,6 +1313,64 @@ mod tests {
         assert_eq!(dash.summary.pageviews, 0);
         assert_eq!(dash.summary.visitors, 0);
         assert!(dash.breakdowns.sources.is_empty());
+
+        drop(store);
+        let _ = std::fs::remove_file(&redb);
+    }
+
+    #[test]
+    fn project_filter_resolves_names_case_insensitively_with_id_fallback() {
+        let redb = temp_redb();
+        let store = Store::open(&redb).unwrap();
+        store
+            .put_project(&analytics_api::Project {
+                id: "01ARZAPPS".into(),
+                name: "Apps".into(),
+                slug: "apps".into(),
+                created_at: Utc::now(),
+            })
+            .unwrap();
+        store
+            .put_source(&analytics_api::Source {
+                uri: "https://a.com".into(),
+                project_id: Some("01ARZAPPS".into()),
+                kind: analytics_api::default_kind("https://a.com"),
+                display_name: None,
+                created_at: Utc::now(),
+                first_seen: None,
+                last_seen: None,
+            })
+            .unwrap();
+        store
+            .append_events(&[
+                load("https://a.com", 1_000, true, None),
+                load("https://b.com", 2_000, true, None), // unassigned, excluded
+            ])
+            .unwrap();
+
+        // The (unique) name selects the project in any case; the id still
+        // resolves so pre-rename links keep working.
+        for q in [
+            r#"project == "Apps""#,
+            r#"project == "APPS""#,
+            r#"project in ["Apps"]"#,
+            r#"project == "01ARZAPPS""#,
+        ] {
+            let filter = dash_filter(&store, q);
+            let dash = dashboard(&store, "/none", Some(&filter), 0, 10_000, 86_400_000).unwrap();
+            assert_eq!(dash.summary.pageviews, 1, "query `{q}`");
+        }
+
+        // Negation excludes the project's traffic but keeps everything else.
+        let filter = dash_filter(&store, r#"project != "Apps""#);
+        let dash = dashboard(&store, "/none", Some(&filter), 0, 10_000, 86_400_000).unwrap();
+        assert_eq!(dash.summary.pageviews, 1);
+        assert!(
+            dash.breakdowns
+                .sources
+                .iter()
+                .all(|r| r.key != "https://a.com")
+        );
 
         drop(store);
         let _ = std::fs::remove_file(&redb);

--- a/agent/src/web/api/projects.rs
+++ b/agent/src/web/api/projects.rs
@@ -26,6 +26,11 @@ pub async fn create(state: web::Data<AppState>, body: web::Json<ProjectInput>) -
     if name.is_empty() {
         return json_error(StatusCode::BAD_REQUEST, "A project name is required.");
     }
+    match name_taken(&state, &name, None) {
+        Ok(false) => {}
+        Ok(true) => return name_conflict(&name),
+        Err(err) => return internal_error(err),
+    }
     let project = Project {
         id: ulid::Ulid::new().to_string(),
         slug: input
@@ -62,6 +67,13 @@ pub async fn update(
     };
     let input = body.into_inner();
     let name = input.name.trim().to_string();
+    if !name.is_empty() {
+        match name_taken(&state, &name, Some(&id)) {
+            Ok(false) => {}
+            Ok(true) => return name_conflict(&name),
+            Err(err) => return internal_error(err),
+        }
+    }
     let updated = Project {
         slug: input
             .slug
@@ -97,6 +109,30 @@ pub async fn delete(state: web::Data<AppState>, path: web::Path<String>) -> Http
             )
         }
     }
+}
+
+/// Whether a project other than `except` already uses `name`. Names are
+/// compared case-insensitively because the filter language resolves
+/// `project == "<name>"` case-insensitively — a duplicate would make that
+/// lookup ambiguous.
+fn name_taken(
+    state: &web::Data<AppState>,
+    name: &str,
+    except: Option<&str>,
+) -> crate::errors::Result<bool> {
+    let needle = name.to_lowercase();
+    Ok(state
+        .store
+        .list_projects()?
+        .iter()
+        .any(|p| p.name.to_lowercase() == needle && Some(p.id.as_str()) != except))
+}
+
+fn name_conflict(name: &str) -> HttpResponse {
+    json_error(
+        StatusCode::CONFLICT,
+        format!("A project named \"{name}\" already exists — project names must be unique."),
+    )
 }
 
 /// Lower-case, hyphenated slug derived from a name.

--- a/ui/src/components/breakdown.rs
+++ b/ui/src/components/breakdown.rs
@@ -120,17 +120,19 @@ pub fn breakdown_panel(props: &BreakdownPanelProps) -> Html {
         .max()
         .unwrap_or(1)
         .max(1);
+    // Case-insensitive, like the server's string comparisons, so a hand-typed
+    // `project == "apps"` still highlights the "Apps" row.
     let selected = props
         .active
         .iter()
         .find(|(d, _)| *d == tab.dim)
-        .map(|(_, v)| v.as_str());
+        .map(|(_, v)| v.to_lowercase());
 
     let rows = ranked.iter().enumerate().map(|(i, row)| {
         let value = row.value_for(metric);
         let share = if total > 0 { value as f64 / total as f64 * 100.0 } else { 0.0 };
         let bar = if max > 0 { value as f64 / max as f64 * 100.0 } else { 0.0 };
-        let is_selected = selected == Some(row.value.as_str());
+        let is_selected = selected.as_deref() == Some(row.value.to_lowercase().as_str());
 
         let onclick = {
             let on_filter = props.on_filter.clone();

--- a/ui/src/components/filter_bar.rs
+++ b/ui/src/components/filter_bar.rs
@@ -38,12 +38,19 @@ pub fn filter_bar(props: &FilterBarProps) -> Html {
     let projects = use_context::<ProjectsContext>();
 
     // ---------------------------------------------------------------- chips
-    let project_name = |id: &str| -> String {
+    // Project filter values are names (matched case-insensitively, like the
+    // server); ids are still resolved so pre-rename links display properly.
+    let project_name = |value: &str| -> String {
+        let needle = value.to_lowercase();
         projects
             .as_ref()
-            .and_then(|c| c.projects.iter().find(|p| p.id == id))
+            .and_then(|c| {
+                c.projects
+                    .iter()
+                    .find(|p| p.name.to_lowercase() == needle || p.id == value)
+            })
             .map(|p| p.name.clone())
-            .unwrap_or_else(|| id.to_string())
+            .unwrap_or_else(|| value.to_string())
     };
 
     let dim_applies = |dim: Dim| {

--- a/ui/src/components/project_drawer.rs
+++ b/ui/src/components/project_drawer.rs
@@ -163,6 +163,7 @@ pub fn project_drawer(props: &ProjectDrawerProps) -> Html {
             props.on_close.clone(),
         );
         let (filters, apply_filters) = (filters.clone(), apply_filters.clone());
+        let project = project.clone();
         Callback::from(move |_: MouseEvent| {
             let confirmed = web_sys::window()
                 .and_then(|w| {
@@ -183,6 +184,9 @@ pub fn project_drawer(props: &ProjectDrawerProps) -> Html {
                 on_close.clone(),
             );
             let (filters, apply_filters) = (filters.clone(), apply_filters.clone());
+            // Filters address projects by name (case-insensitively; old links
+            // by id) — capture the name so deletion can clear a matching chip.
+            let name = project.as_ref().map(|p| p.name.to_lowercase());
             busy.set(true);
             spawn_local(async move {
                 match api::delete_project(&id).await {
@@ -191,7 +195,10 @@ pub fn project_drawer(props: &ProjectDrawerProps) -> Html {
                         on_close.emit(());
                         // Don't strand the dashboard filtered to a project that
                         // no longer exists.
-                        if filters.get(Dim::Project) == Some(id.as_str()) {
+                        let filtered = filters
+                            .get(Dim::Project)
+                            .is_some_and(|v| v == id.as_str() || Some(v.to_lowercase()) == name);
+                        if filtered {
                             apply_filters.emit(filters.without(Dim::Project));
                         }
                     }

--- a/ui/src/components/shell.rs
+++ b/ui/src/components/shell.rs
@@ -177,9 +177,10 @@ pub fn app_shell(props: &AppShellProps) -> Html {
                         }
                         dispatcher.dispatch(());
                         drawer_open.set(false);
-                        // Land on the dashboard filtered to the new project.
+                        // Land on the dashboard filtered to the new project
+                        // (filters address projects by name).
                         if let Some(nav) = &navigator {
-                            let filters = FilterSet::default().with(Dim::Project, project.id);
+                            let filters = FilterSet::default().with(Dim::Project, project.name);
                             let _ = nav.push_with_query(&Route::Overview, &filters.to_pairs());
                         }
                     }

--- a/ui/src/components/sidebar.rs
+++ b/ui/src/components/sidebar.rs
@@ -52,11 +52,16 @@ pub fn sidebar() -> Html {
     let project_items = projects
         .iter()
         .map(|p| {
-            let active = is_dashboard && active_project.as_deref() == Some(p.id.as_str());
+            // Filters address projects by name (matched case-insensitively,
+            // like the server); ids still match for pre-rename links.
+            let active = is_dashboard
+                && active_project
+                    .as_deref()
+                    .is_some_and(|v| v.to_lowercase() == p.name.to_lowercase() || v == p.id);
             let onclick = {
-                let (navigate, filters, id) = (navigate.clone(), filters.clone(), p.id.clone());
+                let (navigate, filters, name) = (navigate.clone(), filters.clone(), p.name.clone());
                 Callback::from(move |_: MouseEvent| {
-                    navigate.emit((Route::Overview, filters.with(Dim::Project, id.clone())));
+                    navigate.emit((Route::Overview, filters.with(Dim::Project, name.clone())));
                 })
             };
             let class = classes!("menu__subitem", active.then_some("menu__subitem--active"));

--- a/ui/src/pages/dashboard.rs
+++ b/ui/src/pages/dashboard.rs
@@ -93,20 +93,33 @@ pub fn dashboard() -> Html {
         .as_ref()
         .map(|c| c.projects.clone())
         .unwrap_or_default();
+    // Filter values address projects by their (unique) name; breakdown rows
+    // arrive keyed by id. Resolve either to the canonical display name.
     let project_name = {
         let projects = projects.clone();
-        move |id: &str| -> String {
+        move |value: &str| -> String {
+            let needle = value.to_lowercase();
             projects
                 .iter()
-                .find(|p| p.id == id)
+                .find(|p| p.name.to_lowercase() == needle || p.id == value)
                 .map(|p| p.name.clone())
-                .unwrap_or_else(|| id.to_string())
+                .unwrap_or_else(|| value.to_string())
         }
     };
 
     let on_manage = {
         let manage_project = manage_project.clone();
-        Callback::from(move |id: String| manage_project.set(Some(id)))
+        let projects = projects.clone();
+        // Rows carry the project *name* (the filter value); the drawer's API
+        // calls need the id.
+        Callback::from(move |value: String| {
+            let id = projects
+                .iter()
+                .find(|p| p.name == value || p.id == value)
+                .map(|p| p.id.clone())
+                .unwrap_or(value);
+            manage_project.set(Some(id));
+        })
     };
     let close_manage = {
         let manage_project = manage_project.clone();
@@ -126,7 +139,7 @@ pub fn dashboard() -> Html {
             projects
                 .iter()
                 .map(|p| SuggestOption {
-                    value: p.id.clone(),
+                    value: p.name.clone(),
                     label: p.name.clone(),
                 })
                 .collect(),
@@ -193,12 +206,14 @@ pub fn dashboard() -> Html {
                     title: (!r.key.is_empty()).then(|| r.key.clone()),
                 })
                 .collect::<Vec<_>>();
+            // Project rows filter (and highlight) by name — the filter value —
+            // not by the id the API keys them with.
             let project_rows = dash
                 .breakdowns
                 .projects
                 .iter()
                 .map(|r| PanelRow {
-                    value: r.key.clone(),
+                    value: project_name(&r.key),
                     label: project_name(&r.key),
                     icon: None,
                     visitors: r.visitors,
@@ -391,7 +406,7 @@ fn build_suggestions(
             projects
                 .iter()
                 .map(|p| SuggestOption {
-                    value: p.id.clone(),
+                    value: p.name.clone(),
                     label: p.name.clone(),
                 })
                 .collect(),

--- a/ui/src/pages/exceptions.rs
+++ b/ui/src/pages/exceptions.rs
@@ -108,8 +108,8 @@ pub fn exceptions() -> Html {
     };
 
     // Suggestions for the (restricted) filter chips on this page: the full
-    // project list (values are ids — free-typed names would match nothing) and
-    // the sources seen in the current listing.
+    // project list (filters address projects by name) and the sources seen in
+    // the current listing.
     let suggestions: Vec<(Dim, Vec<SuggestOption>)> = {
         let sources: Vec<SuggestOption> = match &*data {
             Some(Ok(list)) => {
@@ -131,7 +131,7 @@ pub fn exceptions() -> Html {
         let project_options: Vec<SuggestOption> = projects
             .iter()
             .map(|p| SuggestOption {
-                value: p.id.clone(),
+                value: p.name.clone(),
                 label: p.name.clone(),
             })
             .collect();


### PR DESCRIPTION
## Summary

`project == "Apps"` in the search bar now filters to the project named "Apps". Project filters previously resolved the compared value against project **ids**, so hand-typing a filter in the query bar required knowing a ULID; they now resolve against project **names** (case-insensitively, matching the filter language's string semantics), with an id fallback so pre-existing bookmarked/shared links keep working.

### Server

- `project == "<name>"` / `project != "<name>"` / `project in [...]` resolve the value against project names via a new `project_source_uris_by_name` helper; unknown values still match nothing — never everything (`agent/src/analytics/filter.rs`, `agent/src/analytics/mod.rs`).
- Project names are now enforced **unique** (case-insensitive, trimmed) on create and update — a duplicate would make name-based filtering ambiguous. Conflicts return `409` with a descriptive message (`agent/src/web/api/projects.rs`).

### UI

- Everywhere the UI emitted a project **id** as the filter value now emits the **name**: add-filter suggestions (dashboard + exceptions), project breakdown rows, the sidebar project list, and the post-create "land on the filtered dashboard" navigation.
- Chip/heading display lookups resolve names case-insensitively (ids still resolve for old links), the "Manage project" row action maps the name back to the id the drawer's API calls need, and deleting a project clears a name-addressed filter chip.
- Breakdown row highlighting now compares the active filter value case-insensitively, matching the server's comparison semantics (so a hand-typed `project == "apps"` still highlights the "Apps" row).

### Notes

- Renaming a project renames its filter handle: existing name-based URLs for that project will match nothing until updated (same behavior as deleting). Id-based URLs are unaffected.

## Testing

- New end-to-end test covering name resolution (exact + case-folded), `in` lists, id fallback, and negation.
- `cargo clippy --workspace --all-targets`, `cargo test --workspace` (87 tests), and `cargo clippy` for the wasm UI crate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnwTSk1RuJDvRQQceBKRFE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnwTSk1RuJDvRQQceBKRFE)_