### PR TITLE
Update tracing-batteries to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#cf35de7fad4e013391383219abed2f4d58abe963"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#e1f168e57bb74c146405cf74d6120902fe677926"
 dependencies = [
  "chrono",
  "hex",


### PR DESCRIPTION
Bumps the `tracing-batteries` git dependency pin in `Cargo.lock`:

- Old: `cf35de7fad4e013391383219abed2f4d58abe963`
- New: `e1f168e57bb74c146405cf74d6120902fe677926`

## Verification
- `cargo update tracing-batteries` updated the lockfile pin (no manual `iana-time-zone` bump was needed this time).
- `cargo +nightly check -p analytics` completed successfully (stable rustc cannot build the unrelated transitive `polars-ooc` dependency due to nightly-only stdlib features, which is a pre-existing sandbox limitation unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NutKW958x2VF9rVagycenv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NutKW958x2VF9rVagycenv)_