### PR TITLE
Add event analytics views and source-scoped exception groups

### DIFF
--- a/agent/src/analytics/filter.rs
+++ b/agent/src/analytics/filter.rs
@@ -53,6 +53,9 @@ impl FieldSet {
             (FieldSet::Dashboard, "utm_source") => string("utm_source"),
             (FieldSet::Dashboard, "utm_medium") => string("utm_medium"),
             (FieldSet::Dashboard, "utm_campaign") => string("utm_campaign"),
+            // The name of a custom/pixel event; page views carry none, so an
+            // event filter naturally scopes the view to those events.
+            (FieldSet::Dashboard, "event") => string("event_name"),
             // The application *is* the source (exceptions attribute to the
             // reporting hostname), so `app` is an alias for `source`.
             (FieldSet::Exceptions, "app") => string("source"),
@@ -72,7 +75,7 @@ impl FieldSet {
         match self {
             FieldSet::Dashboard => {
                 "project, source, path, referrer, country, language, browser, version, os, \
-                 device, utm_source, utm_medium, utm_campaign"
+                 device, utm_source, utm_medium, utm_campaign, event"
             }
             FieldSet::Exceptions => {
                 "project, source, browser, version, os, device, app, app_version, type, \
@@ -207,18 +210,19 @@ impl Compiler<'_> {
             // The sentinel means "absent on a page view". Pixel/custom events
             // have *every* dimension null, so on the dashboard field set they
             // must not ride through an empty-valued comparison (the events
-            // metric would ignore the filter entirely). Exception queries run
-            // on a kind-scoped frame where "absent" genuinely means unknown.
+            // metric would ignore the filter entirely). The event-name field
+            // inverts that: it lives only on pixel/custom events, so its
+            // sentinel means "an unnamed event". Exception queries run on a
+            // kind-scoped frame where "absent" genuinely means unknown.
             let absent = col(field.column)
                 .is_null()
                 .or(col(field.column).eq(lit("")));
+            let event_kinds = col("kind")
+                .eq(lit("pixel"))
+                .or(col("kind").eq(lit("custom")));
             return match self.fields {
-                FieldSet::Dashboard => absent.and(
-                    col("kind")
-                        .eq(lit("pixel"))
-                        .or(col("kind").eq(lit("custom")))
-                        .not(),
-                ),
+                FieldSet::Dashboard if field.column == "event_name" => absent.and(event_kinds),
+                FieldSet::Dashboard => absent.and(event_kinds.not()),
                 FieldSet::Exceptions => absent,
             };
         }

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -345,7 +345,6 @@ pub fn exception_detail(
         browsers: count_by(&df, "ua_browser")?,
         operating_systems: count_by(&df, "ua_os")?,
         devices: count_by(&df, "ua_device")?,
-        sources: count_by(&df, "source")?,
     };
     let variants = variants_of(&df, limit)?;
 
@@ -2350,14 +2349,6 @@ mod tests {
             Some(("1.1.0", 2))
         );
         assert!(versions.iter().any(|r| r.key == "1.0.0" && r.count == 1));
-        assert_eq!(
-            detail
-                .breakdowns
-                .sources
-                .first()
-                .map(|r| (r.key.as_str(), r.count)),
-            Some(("https://a.com", 3))
-        );
 
         drop(store);
         let _ = std::fs::remove_file(&redb);

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -9,10 +9,10 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use analytics_api::{
-    BreakdownRow, Breakdowns, CountRow, Dashboard, ExceptionBreakdowns, ExceptionGroup,
-    ExceptionGroupDetail, ExceptionStatus, ExceptionVariant, MetricSummary, SessionTrace,
-    TREND_BUCKETS, TimeSeriesPoint, TraceEvent, TraceEventKind, TraceSummary, VersionRow,
-    pixel_source, source_label,
+    BreakdownRow, Breakdowns, CountRow, Dashboard, EventBreakdowns, EventDetail, EventVariant,
+    ExceptionBreakdowns, ExceptionGroup, ExceptionGroupDetail, ExceptionStatus, ExceptionVariant,
+    MetricSummary, SessionTrace, TREND_BUCKETS, TimeSeriesPoint, TraceEvent, TraceEventKind,
+    TraceSummary, VersionRow, pixel_source, source_label,
 };
 use chrono::{Datelike, TimeZone, Utc};
 use polars::prelude::*;
@@ -88,6 +88,7 @@ pub fn dashboard(
     }
 
     let pageloads = current.clone().filter(col("kind").eq(lit("page_load")));
+    let event_names = event_name_breakdown(current.clone().filter(is_event()))?;
     let per_source = source_rollup(current.clone(), unique_flag)?;
     let (projects, sources, unassigned) = project_rollup(store, per_source)?;
     let traces = recent_traces(current.clone(), TRACE_SAMPLE)?;
@@ -109,6 +110,7 @@ pub fn dashboard(
             utm_sources: breakdown(pageloads.clone(), "utm_source", unique_flag)?,
             utm_mediums: breakdown(pageloads.clone(), "utm_medium", unique_flag)?,
             utm_campaigns: breakdown(pageloads, "utm_campaign", unique_flag)?,
+            event_names,
             projects,
             sources,
         },
@@ -347,17 +349,113 @@ pub fn exception_detail(
     };
     let variants = variants_of(&df, limit)?;
 
-    // The sessions the group's occurrences belonged to, newest first, so the
-    // operator can pick which trace to open. The occurrence frame is already
-    // newest-first; a second scan summarizes those sessions in full (their
-    // page views and events, not just the exceptions).
-    let sid = df
+    let traces = traces_of_occurrences(store, parquet_dir, &df, from_ms, to_ms)?;
+
+    Ok(Some(ExceptionGroupDetail {
+        group,
+        breakdowns,
+        variants,
+        traces,
+    }))
+}
+
+/// One named custom/pixel event in forensic detail: the aggregate (with
+/// trend), how its occurrences distribute across key dimensions, its
+/// **distinct metadata variants** (one representative per unique reporter
+/// payload), and the sessions it occurred in. `filter` is the dashboard's
+/// compiled `q` expression, so the numbers cover the same slice the operator
+/// was looking at. Returns `None` if the event has no occurrences in
+/// `[from_ms, to_ms)`.
+pub fn event_detail(
+    store: &Store,
+    parquet_dir: &str,
+    name: &str,
+    from_ms: i64,
+    to_ms: i64,
+    filter: Option<&CompiledFilter>,
+    limit: usize,
+) -> Result<Option<EventDetail>> {
+    let mut lf = combined(store, parquet_dir, from_ms, to_ms)?
+        .filter(is_event())
+        .filter(col("event_name").eq(lit(name.to_string())));
+    if let Some(filter) = filter {
+        lf = lf.filter(filter.predicate.clone());
+    }
+    let df = lf
+        .select([
+            col("received_ms")
+                .cast(DataType::Int64)
+                .alias("received_ms"),
+            col("source"),
+            col("pathname"),
+            col("country"),
+            col("language"),
+            col("ua_browser"),
+            col("ua_os"),
+            col("ua_device"),
+            col("metadata_json"),
+            col("sid"),
+        ])
+        .sort(
+            ["received_ms"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
+        .collect()
+        .or_system_err(ADVICE)?;
+
+    let height = df.height();
+    if height == 0 {
+        return Ok(None);
+    }
+
+    let received = df
+        .column("received_ms")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+
+    let breakdowns = EventBreakdowns {
+        sources: count_by(&df, "source")?,
+        pages: count_by(&df, "pathname")?,
+        browsers: count_by(&df, "ua_browser")?,
+        operating_systems: count_by(&df, "ua_os")?,
+        devices: count_by(&df, "ua_device")?,
+        countries: count_by(&df, "country")?,
+        languages: count_by(&df, "language")?,
+    };
+    let variants = event_variants(&df, limit)?;
+    let traces = traces_of_occurrences(store, parquet_dir, &df, from_ms, to_ms)?;
+
+    Ok(Some(EventDetail {
+        name: name.to_string(),
+        count: height as i64,
+        first_seen_ms: received.get(height - 1).unwrap_or(0),
+        last_seen_ms: received.get(0).unwrap_or(0),
+        trend: trend_of((0..height).filter_map(|i| received.get(i)), from_ms, to_ms),
+        breakdowns,
+        variants,
+        traces,
+    }))
+}
+
+/// The sessions an (already newest-first) occurrence frame belonged to, newest
+/// first, so the operator can pick which trace to open. A second scan
+/// summarizes those sessions in full — their page views and events, not just
+/// the occurrences that matched.
+fn traces_of_occurrences(
+    store: &Store,
+    parquet_dir: &str,
+    occurrences: &DataFrame,
+    from_ms: i64,
+    to_ms: i64,
+) -> Result<Vec<TraceSummary>> {
+    let sid = occurrences
         .column("sid")
         .or_system_err(ADVICE)?
         .str()
         .or_system_err(ADVICE)?;
     let mut sids: Vec<String> = Vec::new();
-    for i in 0..height {
+    for i in 0..occurrences.height() {
         if let Some(sid) = sid.get(i)
             && !sid.is_empty()
             && !sids.iter().any(|seen| seen == sid)
@@ -368,20 +466,102 @@ pub fn exception_detail(
             }
         }
     }
-    let traces = if sids.is_empty() {
-        Vec::new()
-    } else {
-        let sessions = combined(store, parquet_dir, from_ms, to_ms)?
-            .filter(col("sid").is_in(lit(Series::new("sids".into(), sids)), false));
-        recent_traces(sessions, TRACE_SAMPLE)?
-    };
+    if sids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let sessions = combined(store, parquet_dir, from_ms, to_ms)?
+        .filter(col("sid").is_in(lit(Series::new("sids".into(), sids)), false));
+    recent_traces(sessions, TRACE_SAMPLE)
+}
 
-    Ok(Some(ExceptionGroupDetail {
-        group,
-        breakdowns,
-        variants,
-        traces,
-    }))
+/// Collapse an event's occurrences (already sorted newest-first) into distinct
+/// variants keyed by their reporter metadata: one representative each, counted,
+/// most frequent first. The representative context (client, source, page)
+/// comes from the variant's latest occurrence.
+fn event_variants(occurrences: &DataFrame, limit: usize) -> Result<Vec<EventVariant>> {
+    let df = occurrences
+        .clone()
+        .lazy()
+        .group_by([col("metadata_json")])
+        .agg([
+            len().cast(DataType::Int64).alias("count"),
+            col("received_ms").min().alias("first_seen"),
+            col("received_ms").max().alias("last_seen"),
+            // The frame is newest-first, so `first()` is the latest context.
+            col("ua_browser").first().alias("ua_browser"),
+            col("ua_os").first().alias("ua_os"),
+            col("source").first().alias("source"),
+            col("pathname").first().alias("pathname"),
+            // The session link: the latest occurrence that has one.
+            col("sid").drop_nulls().first().alias("sid"),
+        ])
+        .sort(
+            ["count"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
+        .limit(limit as u32)
+        .collect()
+        .or_system_err(ADVICE)?;
+
+    let metadata = df
+        .column("metadata_json")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let count = df
+        .column("count")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let first = df
+        .column("first_seen")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let last = df
+        .column("last_seen")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+    let browser = df
+        .column("ua_browser")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let os = df
+        .column("ua_os")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let source = df
+        .column("source")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let pathname = df
+        .column("pathname")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let sid = df
+        .column("sid")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+
+    Ok((0..df.height())
+        .map(|i| EventVariant {
+            metadata: metadata.get(i).map(str::to_string),
+            count: count.get(i).unwrap_or(0),
+            first_seen_ms: first.get(i).unwrap_or(0),
+            last_seen_ms: last.get(i).unwrap_or(0),
+            ua_browser: browser.get(i).map(str::to_string),
+            ua_os: os.get(i).map(str::to_string),
+            source: source.get(i).map(str::to_string),
+            pathname: pathname.get(i).map(str::to_string),
+            session_id: sid.get(i).map(str::to_string),
+        })
+        .collect())
 }
 
 /// Occurrence counts per value of `column` (nulls under the empty-string
@@ -421,10 +601,13 @@ fn count_by(occurrences: &DataFrame, column: &str) -> Result<Vec<CountRow>> {
         .collect())
 }
 
-/// Occurrence counts per reported release, keyed as `app @ version` (the app
-/// being the source's label) — a release number is only meaningful within its
-/// application. Occurrences with no reported version aggregate under the
-/// empty sentinel, whichever source they came from.
+/// Occurrence counts per reported release. When the frame spans several
+/// sources, rows are keyed as `app @ version` (the app being the source's
+/// label) — a release number is only meaningful within its application. A
+/// frame scoped to a single source (the per-source detail view) keys rows by
+/// the bare version number, since the application is given. Occurrences with
+/// no reported version aggregate under the empty sentinel, whichever source
+/// they came from.
 fn app_version_rows(occurrences: &DataFrame) -> Result<Vec<CountRow>> {
     let df = occurrences
         .clone()
@@ -454,8 +637,20 @@ fn app_version_rows(occurrences: &DataFrame) -> Result<Vec<CountRow>> {
         .i64()
         .or_system_err(ADVICE)?;
 
-    // Distinct sources can share a label (http vs https), so fold by the
-    // display key rather than trusting the group-by to have finished the job.
+    // Qualify versions with their application only when the frame genuinely
+    // mixes applications; labels are compared (not URIs) since distinct
+    // sources can share one (http vs https).
+    let mut labels: Vec<&str> = (0..df.height())
+        .filter_map(|i| apps.get(i))
+        .filter(|app| !app.is_empty())
+        .map(source_label)
+        .collect();
+    labels.sort_unstable();
+    labels.dedup();
+    let qualify = labels.len() > 1;
+
+    // Fold by the display key rather than trusting the group-by to have
+    // finished the job (see the label-sharing note above).
     let mut totals: HashMap<String, i64> = HashMap::new();
     for i in 0..df.height() {
         let (Some(app), Some(version)) = (apps.get(i), versions.get(i)) else {
@@ -464,7 +659,8 @@ fn app_version_rows(occurrences: &DataFrame) -> Result<Vec<CountRow>> {
         let key = match (app.is_empty(), version.is_empty()) {
             (_, true) => String::new(),
             (true, false) => version.to_string(),
-            (false, false) => format!("{} @ {version}", source_label(app)),
+            (false, false) if qualify => format!("{} @ {version}", source_label(app)),
+            (false, false) => version.to_string(),
         };
         *totals.entry(key).or_insert(0) += counts.get(i).unwrap_or(0);
     }
@@ -896,17 +1092,6 @@ pub fn session_trace(
     }))
 }
 
-/// Sum two trend vectors element-wise (for folding per-source rows into
-/// per-project rows; both are computed on the same `[from, to)` bucket grid).
-pub fn merge_trends(into: &mut Vec<i64>, other: &[i64]) {
-    if into.len() < other.len() {
-        into.resize(other.len(), 0);
-    }
-    for (i, v) in other.iter().enumerate() {
-        into[i] += v;
-    }
-}
-
 // ----------------------------------------------------------------- internals
 
 /// Occurrence timestamps bucketed into [`TREND_BUCKETS`] equal slices of
@@ -1265,6 +1450,46 @@ fn version_breakdown(pageloads: LazyFrame, unique_flag: &str) -> Result<Vec<Vers
                 pageviews: pageviews.get(i).unwrap_or(0),
                 visitors: visitors.get(i).unwrap_or(0),
                 events: 0,
+            })
+        })
+        .collect())
+}
+
+/// The custom/pixel events breakdown, keyed by event name (unnamed events
+/// aggregate under the empty sentinel). Only the `events` count is meaningful —
+/// these rows have no page views, and visitor uniqueness rides on page loads —
+/// so the panel displays them under the Events metric.
+fn event_name_breakdown(events: LazyFrame) -> Result<Vec<BreakdownRow>> {
+    let df = events
+        .with_columns([col("event_name").fill_null(lit("")).alias("key")])
+        .group_by([col("key")])
+        .agg([len().cast(DataType::Int64).alias("events")])
+        .sort(
+            ["events"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
+        .limit(BREAKDOWN_LIMIT)
+        .collect()
+        .or_system_err(ADVICE)?;
+
+    let keys = df
+        .column("key")
+        .or_system_err(ADVICE)?
+        .str()
+        .or_system_err(ADVICE)?;
+    let events = df
+        .column("events")
+        .or_system_err(ADVICE)?
+        .i64()
+        .or_system_err(ADVICE)?;
+
+    Ok((0..df.height())
+        .filter_map(|i| {
+            keys.get(i).map(|key| BreakdownRow {
+                key: key.to_string(),
+                visitors: 0,
+                pageviews: 0,
+                events: events.get(i).unwrap_or(0),
             })
         })
         .collect())
@@ -2116,19 +2341,15 @@ mod tests {
         assert_eq!(detail.traces[0].session_id, "sess-1");
         assert_eq!(detail.traces[0].exceptions, 1);
 
-        // Distributions cover app releases (1.1.0 twice, 1.0.0 once), keyed as
-        // `app @ version` since a release is only meaningful within its app;
-        // the sources card doubles as the per-application distribution.
+        // Distributions cover app releases (1.1.0 twice, 1.0.0 once). All the
+        // occurrences share one source, so versions are keyed bare — the
+        // application is given by the (source-scoped) view.
         let versions = &detail.breakdowns.app_versions;
         assert_eq!(
             versions.first().map(|r| (r.key.as_str(), r.count)),
-            Some(("a.com @ 1.1.0", 2))
+            Some(("1.1.0", 2))
         );
-        assert!(
-            versions
-                .iter()
-                .any(|r| r.key == "a.com @ 1.0.0" && r.count == 1)
-        );
+        assert!(versions.iter().any(|r| r.key == "1.0.0" && r.count == 1));
         assert_eq!(
             detail
                 .breakdowns
@@ -2154,6 +2375,143 @@ mod tests {
             event_name: Some(name.into()),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn dashboard_breaks_down_event_names() {
+        let redb = temp_redb();
+        let store = Store::open(&redb).unwrap();
+        let mut unnamed = custom_in("https://a.com", "s1", 4_000, "ignored");
+        unnamed.event_name = None;
+        store
+            .append_events(&[
+                load("https://a.com", 1_000, true, None),
+                custom_in("https://a.com", "s1", 2_000, "signup"),
+                custom_in("https://a.com", "s1", 3_000, "signup"),
+                custom_in("https://a.com", "s2", 3_500, "checkout"),
+                unnamed,
+            ])
+            .unwrap();
+
+        let dash = dashboard(&store, "/none", None, 0, 10_000, 86_400_000).unwrap();
+        let names: Vec<(&str, i64)> = dash
+            .breakdowns
+            .event_names
+            .iter()
+            .map(|r| (r.key.as_str(), r.events))
+            .collect();
+        // Ranked by count; unnamed events fold under the empty sentinel; page
+        // loads contribute nothing.
+        assert_eq!(names[0], ("signup", 2));
+        assert!(names.contains(&("checkout", 1)));
+        assert!(names.contains(&("", 1)));
+        assert_eq!(names.len(), 3);
+
+        drop(store);
+        let _ = std::fs::remove_file(&redb);
+    }
+
+    #[test]
+    fn event_detail_collapses_metadata_variants() {
+        let redb = temp_redb();
+        let store = Store::open(&redb).unwrap();
+        let mut with_meta = custom_in("https://a.com", "s1", 2_000, "signup");
+        with_meta.metadata_json = Some(r#"{"plan":"pro"}"#.into());
+        with_meta.pathname = Some("/pricing".into());
+        let mut repeat = custom_in("https://a.com", "s2", 3_000, "signup");
+        repeat.metadata_json = Some(r#"{"plan":"pro"}"#.into());
+        repeat.pathname = Some("/pricing".into());
+        repeat.ua_browser = Some("Firefox".into());
+        store
+            .append_events(&[
+                load("https://a.com", 1_000, true, None),
+                with_meta,
+                repeat,
+                custom_in("https://a.com", "s1", 4_000, "signup"),
+                custom_in("https://a.com", "s1", 5_000, "checkout"),
+            ])
+            .unwrap();
+
+        let detail = event_detail(&store, "/none", "signup", 0, 10_000, None, 10)
+            .unwrap()
+            .expect("signup resolves");
+        assert_eq!(detail.name, "signup");
+        assert_eq!(detail.count, 3);
+        assert_eq!(detail.first_seen_ms, 2_000);
+        assert_eq!(detail.last_seen_ms, 4_000);
+        assert_eq!(detail.trend.iter().sum::<i64>(), 3);
+
+        // Two variants: the shared metadata (count 2, context from its latest
+        // occurrence) and the metadata-less one.
+        assert_eq!(detail.variants.len(), 2);
+        let repeated = detail
+            .variants
+            .iter()
+            .find(|v| v.metadata.is_some())
+            .unwrap();
+        assert_eq!(repeated.count, 2);
+        assert_eq!(repeated.metadata.as_deref(), Some(r#"{"plan":"pro"}"#));
+        assert_eq!(repeated.ua_browser.as_deref(), Some("Firefox"));
+        assert_eq!(repeated.pathname.as_deref(), Some("/pricing"));
+        assert_eq!(repeated.session_id.as_deref(), Some("s2"));
+
+        // Distributions cover the event's occurrences only.
+        let pages = &detail.breakdowns.pages;
+        assert!(pages.iter().any(|r| r.key == "/pricing" && r.count == 2));
+
+        // Both sessions surface as traces; the other event name resolves
+        // separately, and an unknown one not at all.
+        assert_eq!(detail.traces.len(), 2);
+        assert!(
+            event_detail(&store, "/none", "checkout", 0, 10_000, None, 10)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            event_detail(&store, "/none", "nope", 0, 10_000, None, 10)
+                .unwrap()
+                .is_none()
+        );
+
+        // The dashboard filter scopes the detail like every other panel.
+        let filter = dash_filter(&store, r#"source == "https://other.com""#);
+        assert!(
+            event_detail(&store, "/none", "signup", 0, 10_000, Some(&filter), 10)
+                .unwrap()
+                .is_none()
+        );
+
+        drop(store);
+        let _ = std::fs::remove_file(&redb);
+    }
+
+    #[test]
+    fn exception_versions_qualify_only_across_sources() {
+        let redb = temp_redb();
+        let store = Store::open(&redb).unwrap();
+        let mut a = exc_on("https://a.com", "g1", 1_000);
+        a.app_version = Some("1.0.0".into());
+        let mut b = exc_on("https://b.com", "g1", 2_000);
+        b.app_version = Some("1.0.0".into());
+        store.append_events(&[a, b]).unwrap();
+
+        // Across two sources the bare number would be ambiguous, so rows stay
+        // qualified as `app @ version`.
+        let sources = ["https://a.com".to_string(), "https://b.com".to_string()];
+        let detail = exception_detail(&store, "/none", &sources, "g1", 0, 10_000, 10)
+            .unwrap()
+            .expect("g1 resolves");
+        let keys: Vec<&str> = detail
+            .breakdowns
+            .app_versions
+            .iter()
+            .map(|r| r.key.as_str())
+            .collect();
+        assert!(keys.contains(&"a.com @ 1.0.0"));
+        assert!(keys.contains(&"b.com @ 1.0.0"));
+
+        drop(store);
+        let _ = std::fs::remove_file(&redb);
     }
 
     #[test]

--- a/agent/src/web/api/events.rs
+++ b/agent/src/web/api/events.rs
@@ -1,0 +1,80 @@
+//! Custom/pixel event detail: one named event's aggregate, distributions,
+//! metadata exemplars, and session traces.
+
+use actix_web::http::StatusCode;
+use actix_web::{HttpResponse, web};
+use analytics_api::EventDetail;
+use serde::Deserialize;
+use tracing_batteries::prelude::*;
+
+use super::query::resolve_range;
+use super::{internal_error, json_error};
+use crate::analytics::{self, filter::FieldSet};
+use crate::state::AppState;
+
+const VARIANT_LIMIT: usize = 50;
+
+/// Query parameters for the event detail. The name rides in the query string
+/// (not the path) because event names are reporter-chosen free text — slashes
+/// and spaces must not break routing. `q` uses the dashboard field vocabulary,
+/// so the detail covers the same slice as the panel that linked here.
+#[derive(Deserialize)]
+pub struct EventDetailQuery {
+    pub name: String,
+    pub from: Option<i64>,
+    pub to: Option<i64>,
+    pub q: Option<String>,
+}
+
+/// `GET /api/v1/events?name=…` — one event name in forensic detail.
+///
+/// Without an explicit range this looks across **all time**, anchored at the
+/// earliest stored event so the trend buckets cover the data: an event linked
+/// from an old bookmark must always open.
+pub async fn detail(
+    state: web::Data<AppState>,
+    query: web::Query<EventDetailQuery>,
+) -> HttpResponse {
+    let query = query.into_inner();
+    let store = state.store.clone();
+    let parquet_dir = state.config.storage.parquet_dir.clone();
+
+    let filter = match query.q.as_deref() {
+        Some(q) => match analytics::filter::compile_query(q, FieldSet::Dashboard, &store) {
+            Ok(filter) => filter,
+            Err(message) => return json_error(StatusCode::BAD_REQUEST, message),
+        },
+        None => None,
+    };
+
+    let result = web::block(move || -> crate::errors::Result<Option<EventDetail>> {
+        let from = match query.from {
+            Some(f) if f <= 0 => analytics::earliest_event_ms(&store, &parquet_dir)?,
+            other => other,
+        };
+        let (from, to, _) = resolve_range(from, query.to, None);
+        analytics::event_detail(
+            &store,
+            &parquet_dir,
+            &query.name,
+            from,
+            to,
+            filter.as_ref(),
+            VARIANT_LIMIT,
+        )
+    })
+    .await;
+
+    match result {
+        Ok(Ok(Some(detail))) => HttpResponse::Ok().json(detail),
+        Ok(Ok(None)) => json_error(StatusCode::NOT_FOUND, "Event not found."),
+        Ok(Err(err)) => internal_error(err),
+        Err(err) => {
+            error!("event detail task failed: {err}");
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load the event.",
+            )
+        }
+    }
+}

--- a/agent/src/web/api/exceptions.rs
+++ b/agent/src/web/api/exceptions.rs
@@ -14,7 +14,7 @@ use super::query::resolve_range;
 use super::{Authenticated, internal_error, json_error};
 use crate::analytics::{self, filter::FieldSet};
 use crate::state::AppState;
-use crate::store::{ExceptionTriage, Store};
+use crate::store::ExceptionTriage;
 
 const VARIANT_LIMIT: usize = 50;
 
@@ -24,20 +24,6 @@ const VARIANT_LIMIT: usize = 50;
 /// so the `@` join is unambiguous.
 fn scoped_group(group_id: &str, source: &str) -> String {
     format!("{group_id}@{source}")
-}
-
-/// Look up triage for a source-scoped group, falling back to the pre-source
-/// project-wide key so records written before source scoping keep applying.
-fn get_triage_scoped(
-    store: &Store,
-    project_id: &str,
-    group_id: &str,
-    source: &str,
-) -> crate::errors::Result<Option<ExceptionTriage>> {
-    if let Some(triage) = store.get_triage(project_id, &scoped_group(group_id, source))? {
-        return Ok(Some(triage));
-    }
-    store.get_triage(project_id, group_id)
 }
 
 /// Query parameters for the global exceptions inbox: a time range plus a
@@ -105,7 +91,9 @@ pub async fn list_all(
             let project_id = uri_project.get(&source).cloned();
             let mut project_name = None;
             if let Some(pid) = &project_id {
-                if let Some(triage) = get_triage_scoped(&store, pid, &group.group_id, &source)? {
+                if let Some(triage) =
+                    store.get_triage(pid, &scoped_group(&group.group_id, &source))?
+                {
                     group.status = triage.status;
                     group.note = triage.note;
                 }
@@ -139,10 +127,9 @@ pub async fn list_all(
 #[derive(Deserialize)]
 pub struct DetailQuery {
     project: String,
-    /// The source URI the group was seen on. Scopes the detail (and its triage
-    /// state) to that one application; absent on pre-source links, which fall
-    /// back to the project-wide aggregate.
-    source: Option<String>,
+    /// The source URI the group was seen on — part of the group's identity,
+    /// scoping the detail and its triage state to that one application.
+    source: String,
     from: Option<i64>,
     to: Option<i64>,
 }
@@ -160,11 +147,10 @@ pub async fn detail(
 ) -> HttpResponse {
     let group_id = path.into_inner();
     let project_id = query.project.clone();
-    let source = query
-        .source
-        .clone()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
+    let source = query.source.trim().to_string();
+    if source.is_empty() {
+        return json_error(StatusCode::BAD_REQUEST, "A source is required.");
+    }
     let now = Utc::now().timestamp_millis();
     let to = query
         .to
@@ -176,10 +162,7 @@ pub async fn detail(
 
     let result = web::block(
         move || -> crate::errors::Result<Option<ExceptionGroupDetail>> {
-            let sources = match &source {
-                Some(source) => vec![source.clone()],
-                None => analytics::project_source_uris(&store, &project_id)?,
-            };
+            let sources = [source.clone()];
             let Some(mut detail) = analytics::exception_detail(
                 &store,
                 &parquet_dir,
@@ -192,11 +175,9 @@ pub async fn detail(
             else {
                 return Ok(None);
             };
-            let triage = match &source {
-                Some(source) => get_triage_scoped(&store, &project_id, &group_id, source)?,
-                None => store.get_triage(&project_id, &group_id)?,
-            };
-            if let Some(triage) = triage {
+            if let Some(triage) =
+                store.get_triage(&project_id, &scoped_group(&group_id, &source))?
+            {
                 detail.group.status = triage.status;
                 detail.group.note = triage.note;
             }
@@ -240,21 +221,14 @@ pub async fn triage(
         updated_by,
     };
 
-    // Source-scoped when the client says which source the group was seen on;
-    // bare (project-wide) only for pre-source clients.
-    let group_key = match input
-        .source
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        Some(source) => scoped_group(&group_id, source),
-        None => group_id,
-    };
+    let source = input.source.trim();
+    if source.is_empty() {
+        return json_error(StatusCode::BAD_REQUEST, "A source is required.");
+    }
 
     match state
         .store
-        .put_triage(&input.project_id, &group_key, &triage)
+        .put_triage(&input.project_id, &scoped_group(&group_id, source), &triage)
     {
         Ok(()) => HttpResponse::NoContent().finish(),
         Err(err) => internal_error(err),

--- a/agent/src/web/api/exceptions.rs
+++ b/agent/src/web/api/exceptions.rs
@@ -14,9 +14,31 @@ use super::query::resolve_range;
 use super::{Authenticated, internal_error, json_error};
 use crate::analytics::{self, filter::FieldSet};
 use crate::state::AppState;
-use crate::store::ExceptionTriage;
+use crate::store::{ExceptionTriage, Store};
 
 const VARIANT_LIMIT: usize = 50;
+
+/// The triage-store group key for a source-scoped exception group. Triage is
+/// per `(project, fingerprint, source)` — the same fingerprint on two
+/// applications is two independent failures. The fingerprint is 16 hex chars,
+/// so the `@` join is unambiguous.
+fn scoped_group(group_id: &str, source: &str) -> String {
+    format!("{group_id}@{source}")
+}
+
+/// Look up triage for a source-scoped group, falling back to the pre-source
+/// project-wide key so records written before source scoping keep applying.
+fn get_triage_scoped(
+    store: &Store,
+    project_id: &str,
+    group_id: &str,
+    source: &str,
+) -> crate::errors::Result<Option<ExceptionTriage>> {
+    if let Some(triage) = store.get_triage(project_id, &scoped_group(group_id, source))? {
+        return Ok(Some(triage));
+    }
+    store.get_triage(project_id, group_id)
+}
 
 /// Query parameters for the global exceptions inbox: a time range plus a
 /// filt-rs `q` expression over the dimensions exception events carry
@@ -74,45 +96,27 @@ pub async fn list_all(
             .map(|p| (p.id, p.name))
             .collect();
 
-        // Fold per-(fingerprint, source) rows up to per-(fingerprint, project) rows
-        // so a project's count matches its detail page. Unassigned sources are keyed
-        // by source so each stays its own row (no project to merge into). Trends are
-        // summed element-wise — every row shares the same [from, to) bucket grid.
-        use std::collections::hash_map::Entry;
-        let mut acc: HashMap<(String, String), GlobalException> = HashMap::new();
-        for (group, source) in per_source {
+        // One row per (fingerprint, source): a group's identity is the failure
+        // *on that application* — the same fingerprint on two sources is two
+        // independent rows, each annotated with its owning project (when the
+        // source is assigned) for display and triage.
+        let mut out: Vec<GlobalException> = Vec::with_capacity(per_source.len());
+        for (mut group, source) in per_source {
             let project_id = uri_project.get(&source).cloned();
-            let bucket = project_id.clone().unwrap_or_else(|| format!("@{source}"));
-            let key = (group.group_id.clone(), bucket);
-            match acc.entry(key) {
-                Entry::Occupied(mut e) => {
-                    let g = &mut e.get_mut().group;
-                    g.count += group.count;
-                    g.first_seen_ms = g.first_seen_ms.min(group.first_seen_ms);
-                    g.last_seen_ms = g.last_seen_ms.max(group.last_seen_ms);
-                    analytics::merge_trends(&mut g.trend, &group.trend);
+            let mut project_name = None;
+            if let Some(pid) = &project_id {
+                if let Some(triage) = get_triage_scoped(&store, pid, &group.group_id, &source)? {
+                    group.status = triage.status;
+                    group.note = triage.note;
                 }
-                Entry::Vacant(e) => {
-                    e.insert(GlobalException {
-                        group,
-                        project_id,
-                        project_name: None,
-                        source,
-                    });
-                }
+                project_name = project_names.get(pid).cloned();
             }
-        }
-
-        let mut out: Vec<GlobalException> = Vec::with_capacity(acc.len());
-        for (_, mut item) in acc {
-            if let Some(pid) = &item.project_id {
-                if let Some(triage) = store.get_triage(pid, &item.group.group_id)? {
-                    item.group.status = triage.status;
-                    item.group.note = triage.note;
-                }
-                item.project_name = project_names.get(pid).cloned();
-            }
-            out.push(item);
+            out.push(GlobalException {
+                group,
+                project_id,
+                project_name,
+                source,
+            });
         }
         out.sort_by_key(|e| std::cmp::Reverse(e.group.last_seen_ms));
         Ok(out)
@@ -135,11 +139,16 @@ pub async fn list_all(
 #[derive(Deserialize)]
 pub struct DetailQuery {
     project: String,
+    /// The source URI the group was seen on. Scopes the detail (and its triage
+    /// state) to that one application; absent on pre-source links, which fall
+    /// back to the project-wide aggregate.
+    source: Option<String>,
     from: Option<i64>,
     to: Option<i64>,
 }
 
-/// `GET /api/v1/exceptions/{group_id}?project=…` — a group with recent occurrences.
+/// `GET /api/v1/exceptions/{group_id}?project=…&source=…` — a group with
+/// recent occurrences, scoped to the source it was seen on.
 ///
 /// Without an explicit range this looks across **all time**: a group linked
 /// from the inbox (which may cover a 12-month window) or from an old bookmark
@@ -151,6 +160,11 @@ pub async fn detail(
 ) -> HttpResponse {
     let group_id = path.into_inner();
     let project_id = query.project.clone();
+    let source = query
+        .source
+        .clone()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     let now = Utc::now().timestamp_millis();
     let to = query
         .to
@@ -162,7 +176,10 @@ pub async fn detail(
 
     let result = web::block(
         move || -> crate::errors::Result<Option<ExceptionGroupDetail>> {
-            let sources = analytics::project_source_uris(&store, &project_id)?;
+            let sources = match &source {
+                Some(source) => vec![source.clone()],
+                None => analytics::project_source_uris(&store, &project_id)?,
+            };
             let Some(mut detail) = analytics::exception_detail(
                 &store,
                 &parquet_dir,
@@ -175,7 +192,11 @@ pub async fn detail(
             else {
                 return Ok(None);
             };
-            if let Some(triage) = store.get_triage(&project_id, &group_id)? {
+            let triage = match &source {
+                Some(source) => get_triage_scoped(&store, &project_id, &group_id, source)?,
+                None => store.get_triage(&project_id, &group_id)?,
+            };
+            if let Some(triage) = triage {
                 detail.group.status = triage.status;
                 detail.group.note = triage.note;
             }
@@ -219,9 +240,21 @@ pub async fn triage(
         updated_by,
     };
 
+    // Source-scoped when the client says which source the group was seen on;
+    // bare (project-wide) only for pre-source clients.
+    let group_key = match input
+        .source
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(source) => scoped_group(&group_id, source),
+        None => group_id,
+    };
+
     match state
         .store
-        .put_triage(&input.project_id, &group_id, &triage)
+        .put_triage(&input.project_id, &group_key, &triage)
     {
         Ok(()) => HttpResponse::NoContent().finish(),
         Err(err) => internal_error(err),

--- a/agent/src/web/api/mod.rs
+++ b/agent/src/web/api/mod.rs
@@ -6,6 +6,7 @@
 //! mutating requests, and rate-limits unauthenticated callers by IP.
 
 mod auth;
+mod events;
 mod exceptions;
 mod instance;
 mod me;
@@ -90,6 +91,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                     .route("/pixels/{id}", web::get().to(pixels::get))
                     .route("/pixels/{id}", web::put().to(pixels::update))
                     .route("/pixels/{id}", web::delete().to(pixels::delete))
+                    .route("/events", web::get().to(events::detail))
                     .route("/exceptions", web::get().to(exceptions::list_all))
                     .route("/exceptions/{group}", web::get().to(exceptions::detail))
                     .route("/exceptions/{group}", web::patch().to(exceptions::triage))

--- a/api/src/event.rs
+++ b/api/src/event.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+
+/// How a custom/pixel event's occurrences distribute across key dimensions
+/// (empty keys mean the dimension was absent on those occurrences). Custom
+/// events are enriched like page views, so the full dimension set applies;
+/// pixel hits carry almost none of it and fold under the sentinels.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct EventBreakdowns {
+    pub sources: Vec<crate::CountRow>,
+    /// The pages the event fired on.
+    pub pages: Vec<crate::CountRow>,
+    pub browsers: Vec<crate::CountRow>,
+    pub operating_systems: Vec<crate::CountRow>,
+    pub devices: Vec<crate::CountRow>,
+    /// ISO country codes (the UI maps them to names/flags).
+    pub countries: Vec<crate::CountRow>,
+    pub languages: Vec<crate::CountRow>,
+}
+
+/// A distinct example within an event's occurrences: those sharing the same
+/// reporter-supplied metadata, collapsed into one representative with a count.
+/// The detail page scrubs through these rather than paging a flat list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventVariant {
+    /// Reporter-supplied metadata as a raw JSON object string; `None` groups
+    /// the metadata-less occurrences.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<String>,
+    /// How many occurrences share this exact metadata.
+    pub count: i64,
+    pub first_seen_ms: i64,
+    pub last_seen_ms: i64,
+    /// Client context from the most recent occurrence of this variant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ua_browser: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ua_os: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// The page the most recent occurrence fired on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pathname: Option<String>,
+    /// The session the most recent session-linked occurrence belonged to,
+    /// linking the exemplar to its session trace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+/// One named custom/pixel event in forensic detail, for
+/// `GET /api/v1/events?name=…`: the aggregate (with an occurrence trend on the
+/// same bucket grid as exception trends), dimension distributions, distinct
+/// metadata exemplars, and the sessions it occurred in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventDetail {
+    pub name: String,
+    pub count: i64,
+    pub first_seen_ms: i64,
+    pub last_seen_ms: i64,
+    /// Occurrence counts over the query range, split into
+    /// [`crate::TREND_BUCKETS`] equal buckets (oldest first).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trend: Vec<i64>,
+    #[serde(default)]
+    pub breakdowns: EventBreakdowns,
+    pub variants: Vec<EventVariant>,
+    /// The most recent sessions the event occurred in (newest first).
+    #[serde(default)]
+    pub traces: Vec<crate::TraceSummary>,
+}

--- a/api/src/exception.rs
+++ b/api/src/exception.rs
@@ -147,11 +147,17 @@ pub struct GlobalException {
     pub source: String,
 }
 
-/// Payload for updating an exception group's triage state.
+/// Payload for updating an exception group's triage state. Triage is scoped to
+/// the group's source (the same fingerprint on two applications is two
+/// independent failures); `source` is optional only for compatibility with
+/// pre-source clients, whose triage applies project-wide.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriageInput {
     pub project_id: String,
     pub status: ExceptionStatus,
     #[serde(default)]
     pub note: Option<String>,
+    /// The source URI the triaged group was seen on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }

--- a/api/src/exception.rs
+++ b/api/src/exception.rs
@@ -105,18 +105,18 @@ pub struct ExceptionVariant {
 }
 
 /// How a group's occurrences distribute across key dimensions (empty keys mean
-/// the dimension was absent on those occurrences). Applications are identified
-/// by source, so the sources distribution *is* the per-app distribution.
+/// the dimension was absent on those occurrences). The detail view is scoped
+/// to one source, so there is no per-source distribution — the source is part
+/// of the group's identity.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ExceptionBreakdowns {
-    /// Reported releases, keyed as `app @ version` (the app being the source's
-    /// label) since a release number is only meaningful within its application.
-    /// Versionless occurrences aggregate under the empty sentinel.
+    /// Reported releases, keyed by bare version number (the application is
+    /// given by the view's source). Versionless occurrences aggregate under
+    /// the empty sentinel.
     pub app_versions: Vec<crate::CountRow>,
     pub browsers: Vec<crate::CountRow>,
     pub operating_systems: Vec<crate::CountRow>,
     pub devices: Vec<crate::CountRow>,
-    pub sources: Vec<crate::CountRow>,
 }
 
 /// An exception group with its dimension distributions and distinct examples.
@@ -148,9 +148,8 @@ pub struct GlobalException {
 }
 
 /// Payload for updating an exception group's triage state. Triage is scoped to
-/// the group's source (the same fingerprint on two applications is two
-/// independent failures); `source` is optional only for compatibility with
-/// pre-source clients, whose triage applies project-wide.
+/// the group's source — the same fingerprint on two applications is two
+/// independent failures.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriageInput {
     pub project_id: String,
@@ -158,6 +157,5 @@ pub struct TriageInput {
     #[serde(default)]
     pub note: Option<String>,
     /// The source URI the triaged group was seen on.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
+    pub source: String,
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,6 +5,7 @@
 //! server and by the WebAssembly `analytics-ui` frontend.
 
 mod auth;
+mod event;
 mod exception;
 mod health;
 mod instance;
@@ -16,6 +17,7 @@ mod trace;
 mod track;
 
 pub use auth::{AdminUser, CsrfToken};
+pub use event::{EventBreakdowns, EventDetail, EventVariant};
 pub use exception::{
     ExceptionBreakdowns, ExceptionGroup, ExceptionGroupDetail, ExceptionReport, ExceptionStatus,
     ExceptionVariant, GlobalException, TREND_BUCKETS, TriageInput,

--- a/api/src/stats.rs
+++ b/api/src/stats.rs
@@ -131,6 +131,11 @@ pub struct Breakdowns {
     pub utm_sources: Vec<BreakdownRow>,
     pub utm_mediums: Vec<BreakdownRow>,
     pub utm_campaigns: Vec<BreakdownRow>,
+    /// Custom/pixel events keyed by event name (`events` carries the count;
+    /// page-view columns are zero). `serde(default)` tolerates payloads from
+    /// agents predating the column.
+    #[serde(default)]
+    pub event_names: Vec<BreakdownRow>,
     /// Keyed by project id (the UI maps ids to names). Includes pixel and
     /// custom events in `events`.
     pub projects: Vec<BreakdownRow>,

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -267,17 +267,19 @@ pub async fn event_detail(name: &str, query: &str) -> Result<EventDetail, ApiErr
 /// `range` is a pre-encoded `from=…&to=…` pair (empty for the server's
 /// all-time default) so the detail numbers cover the same window as the inbox
 /// row the operator clicked. `source` scopes the group to the application it
-/// was seen on (`None` only on pre-source deep links).
+/// was seen on — it is part of the group's identity.
 pub async fn exception_detail(
     group: &str,
     project: &str,
-    source: Option<&str>,
+    source: &str,
     range: &str,
 ) -> Result<ExceptionGroupDetail, ApiError> {
-    let mut url = format!("/exceptions/{}?project={}", enc(group), enc(project));
-    if let Some(source) = source {
-        url.push_str(&format!("&source={}", enc(source)));
-    }
+    let mut url = format!(
+        "/exceptions/{}?project={}&source={}",
+        enc(group),
+        enc(project),
+        enc(source)
+    );
     if !range.is_empty() {
         url.push('&');
         url.push_str(range);

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -10,8 +10,8 @@
 use std::cell::RefCell;
 
 use analytics_api::{
-    AdminUser, CsrfToken, Dashboard, ExceptionGroupDetail, GlobalException, Instance, Pixel,
-    PixelInput, Project, ProjectInput, SessionTrace, Source, SourceInput, TriageInput,
+    AdminUser, CsrfToken, Dashboard, EventDetail, ExceptionGroupDetail, GlobalException, Instance,
+    Pixel, PixelInput, Project, ProjectInput, SessionTrace, Source, SourceInput, TriageInput,
 };
 use gloo_net::http::Request;
 use serde::Serialize;
@@ -252,15 +252,32 @@ pub async fn list_all_exceptions(query: &str) -> Result<Vec<GlobalException>, Ap
     get_json(&format!("/exceptions?{query}")).await
 }
 
+/// One custom/pixel event in detail. `query` is a pre-encoded dashboard query
+/// (range + `q`) so the numbers cover the same slice as the panel that linked
+/// here.
+pub async fn event_detail(name: &str, query: &str) -> Result<EventDetail, ApiError> {
+    let mut url = format!("/events?name={}", enc(name));
+    if !query.is_empty() {
+        url.push('&');
+        url.push_str(query);
+    }
+    get_json(&url).await
+}
+
 /// `range` is a pre-encoded `from=…&to=…` pair (empty for the server's
 /// all-time default) so the detail numbers cover the same window as the inbox
-/// row the operator clicked.
+/// row the operator clicked. `source` scopes the group to the application it
+/// was seen on (`None` only on pre-source deep links).
 pub async fn exception_detail(
     group: &str,
     project: &str,
+    source: Option<&str>,
     range: &str,
 ) -> Result<ExceptionGroupDetail, ApiError> {
     let mut url = format!("/exceptions/{}?project={}", enc(group), enc(project));
+    if let Some(source) = source {
+        url.push_str(&format!("&source={}", enc(source)));
+    }
     if !range.is_empty() {
         url.push('&');
         url.push_str(range);

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -23,6 +23,11 @@ pub enum Route {
     Project { id: String },
     #[at("/projects/:project/exceptions/:group")]
     Exception { project: String, group: String },
+    /// One custom/pixel event in detail. The event name rides in the query
+    /// string (`?name=…`) — names are reporter-chosen free text, so encoding
+    /// them into the path would break routing on slashes and spaces.
+    #[at("/events")]
+    Event,
     /// One session's event timeline, keyed by the tracker's session id.
     #[at("/traces/:id")]
     Trace { id: String },
@@ -150,6 +155,7 @@ fn switch(route: Route) -> Html {
         Route::Exception { project, group } => {
             html! { <pages::ExceptionDetail {project} {group} /> }
         }
+        Route::Event => html! { <pages::EventDetail /> },
         Route::Trace { id } => html! { <pages::Trace {id} /> },
         Route::Pixels => html! { <pages::Pixels /> },
         Route::Settings => html! { <pages::Settings /> },

--- a/ui/src/components/_exceptions.scss
+++ b/ui/src/components/_exceptions.scss
@@ -104,6 +104,12 @@
     font-weight: 500;
   }
 
+  // The application the group failed on (groups are per source).
+  &__source {
+    font-size: 0.74rem;
+    color: var(--text-4);
+  }
+
   &__trend {
     width: 110px;
     flex-shrink: 0;
@@ -128,27 +134,41 @@
   }
 }
 
-// Detail header: status, message, actions, and the trend sparkline.
+// Detail header (exceptions and events alike): the identity line — status,
+// type, exemplar message — with the triage actions floated to its end, the
+// meta line beneath, and the trend sparkline across the card's full width.
 .exc-head {
   display: flex;
-  align-items: stretch;
-  gap: 1.5rem;
+  flex-direction: column;
+  gap: 0.55rem;
   margin-top: 0;
 
-  &__status {
-    flex: 1;
-    min-width: 0;
+  &__top {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+  }
+
+  &__title {
+    display: flex;
+    align-items: baseline;
     gap: 0.55rem;
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  &__type {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--brand-2);
   }
 
   &__message {
-    margin: 0;
     font-family: var(--font-mono);
-    font-size: 0.92rem;
-    color: var(--text);
+    font-size: 0.88rem;
+    color: var(--text-2);
     word-break: break-word;
   }
 
@@ -157,23 +177,96 @@
   }
 
   &__actions {
+    margin-left: auto;
+    align-self: flex-start;
     display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    margin-top: 0.25rem;
+    gap: 0.45rem;
+    flex-shrink: 0;
   }
 
   &__trend {
-    width: 220px;
-    flex-shrink: 0;
+    width: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     gap: 0.45rem;
+    margin-top: 0.2rem;
   }
 
   &__spark {
-    height: 48px;
+    width: 100%;
+    height: 56px;
+
+    // Event trends are traffic, not trouble — brand teal, not amber.
+    &--brand .sparkline__line {
+      stroke: var(--brand);
+    }
+    &--brand .sparkline__area {
+      fill: var(--brand-soft);
+    }
+  }
+}
+
+// The triage actions: square icon chips whose colour + glyph carry the verb
+// (green check = resolve, violet muted bell = ignore, struck check = reopen).
+// The current state's action renders disabled.
+.exc-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    border-color var(--transition);
+
+  svg {
+    width: 17px;
+    height: 17px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+
+  &--resolve {
+    color: var(--ok);
+    background: var(--ok-soft);
+
+    &:hover:not(:disabled) {
+      border-color: var(--ok);
+    }
+  }
+
+  &--ignore {
+    color: var(--mute);
+    background: var(--mute-soft);
+
+    &:hover:not(:disabled) {
+      border-color: var(--mute);
+    }
+  }
+
+  // A white checkmark struck through in red: "this is no longer resolved".
+  &--reopen {
+    color: var(--text);
+    background: var(--surface-3);
+
+    .icon-strike {
+      stroke: var(--danger);
+    }
+
+    &:hover:not(:disabled) {
+      border-color: var(--danger);
+    }
   }
 }
 
@@ -183,6 +276,11 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
   margin: 0.5rem 0 1.5rem;
+
+  // Event detail pages: volume reads in brand teal, not incident red.
+  &--brand .dist__bar {
+    background: var(--brand-soft);
+  }
 }
 
 .dist {
@@ -339,13 +437,8 @@
   .exc-row__trend {
     display: none;
   }
-  .exc-head {
-    flex-direction: column;
-    gap: 0.75rem;
-
-    &__trend {
-      width: 100%;
-    }
+  .exc-head__top {
+    flex-wrap: wrap;
   }
   .dist-grid {
     grid-template-columns: 1fr;

--- a/ui/src/components/_exceptions.scss
+++ b/ui/src/components/_exceptions.scss
@@ -176,12 +176,15 @@
     font-size: 0.8rem;
   }
 
+  // The triage controls: a segmented button group, joined edge to edge.
   &__actions {
     margin-left: auto;
     align-self: flex-start;
-    display: flex;
-    gap: 0.45rem;
+    display: inline-flex;
     flex-shrink: 0;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
   }
 
   &__trend {
@@ -206,31 +209,32 @@
   }
 }
 
-// The triage actions: square icon chips whose colour + glyph carry the verb
-// (green check = resolve, violet muted bell = ignore, struck check = reopen).
-// The current state's action renders disabled.
+// One segment of the triage group: colour + glyph carry the verb (green
+// check = resolve, violet muted bell = mute, struck check = reopen, violet
+// bell = unmute). Only the transitions that apply to the group's current
+// state are rendered.
 .exc-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
+  width: 2.1rem;
   height: 2rem;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border-strong);
+  border: none;
   background: var(--surface-2);
   cursor: pointer;
-  transition:
-    background var(--transition),
-    border-color var(--transition);
+  transition: filter var(--transition);
+
+  & + & {
+    border-left: 1px solid var(--border-strong);
+  }
 
   svg {
     width: 17px;
     height: 17px;
   }
 
-  &:disabled {
-    opacity: 0.4;
-    cursor: default;
+  &:hover {
+    filter: brightness(1.35);
   }
 
   &:focus-visible {
@@ -240,19 +244,11 @@
   &--resolve {
     color: var(--ok);
     background: var(--ok-soft);
-
-    &:hover:not(:disabled) {
-      border-color: var(--ok);
-    }
   }
 
   &--ignore {
     color: var(--mute);
     background: var(--mute-soft);
-
-    &:hover:not(:disabled) {
-      border-color: var(--mute);
-    }
   }
 
   // A white checkmark struck through in red: "this is no longer resolved".
@@ -262,10 +258,6 @@
 
     .icon-strike {
       stroke: var(--danger);
-    }
-
-    &:hover:not(:disabled) {
-      border-color: var(--danger);
     }
   }
 }

--- a/ui/src/components/breakdown.rs
+++ b/ui/src/components/breakdown.rs
@@ -39,6 +39,24 @@ impl PanelRow {
     }
 }
 
+/// The glyph rendered on a tab's per-row action.
+#[derive(Clone, Copy, PartialEq)]
+pub enum ActionIcon {
+    /// Configure the row's entity (e.g. "manage project").
+    Gear,
+    /// Open the row's detail page.
+    Open,
+}
+
+impl ActionIcon {
+    fn render(self) -> Html {
+        match self {
+            ActionIcon::Gear => icons::gear(),
+            ActionIcon::Open => icons::chevron_right(),
+        }
+    }
+}
+
 /// One tab of a panel: a labelled set of rows filtering one dimension.
 #[derive(Clone, PartialEq)]
 pub struct PanelTab {
@@ -49,6 +67,8 @@ pub struct PanelTab {
     pub action: Option<Callback<String>>,
     /// The icon title for the per-row action.
     pub action_title: &'static str,
+    /// The glyph for the per-row action (a gear unless overridden).
+    pub action_icon: ActionIcon,
 }
 
 impl PanelTab {
@@ -59,12 +79,18 @@ impl PanelTab {
             rows,
             action: None,
             action_title: "",
+            action_icon: ActionIcon::Gear,
         }
     }
 
     pub fn with_action(mut self, title: &'static str, action: Callback<String>) -> Self {
         self.action = Some(action);
         self.action_title = title;
+        self
+    }
+
+    pub fn with_action_icon(mut self, icon: ActionIcon) -> Self {
+        self.action_icon = icon;
         self
     }
 }
@@ -79,6 +105,11 @@ pub struct BreakdownPanelProps {
     /// The active filter value per dimension (highlights the selected row).
     #[prop_or_default]
     pub active: Vec<(Dim, String)>,
+    /// When set, the panel adopts this tab index whenever the value *changes*
+    /// (e.g. the pages panel follows the dashboard metric to its Events tab).
+    /// Manual tab clicks still work in between changes.
+    #[prop_or_default]
+    pub select_tab: Option<usize>,
 }
 
 /// Rows shown per panel before the "Show all" affordance takes over — enough
@@ -88,8 +119,24 @@ const VISIBLE_ROWS: usize = 8;
 
 #[function_component(BreakdownPanel)]
 pub fn breakdown_panel(props: &BreakdownPanelProps) -> Html {
-    let tab_index = use_state(|| 0usize);
+    let tab_index = use_state(|| props.select_tab.unwrap_or(0));
     let expanded = use_state(|| false);
+
+    // Follow externally-driven tab selection (fires only when the value
+    // changes, so it never overrides a manual click in between).
+    {
+        let (tab_index, expanded) = (tab_index.clone(), expanded.clone());
+        use_effect_with(props.select_tab, move |select| {
+            if let Some(i) = *select
+                && *tab_index != i
+            {
+                tab_index.set(i);
+                expanded.set(false);
+            }
+            || ()
+        });
+    }
+
     let index = (*tab_index).min(props.tabs.len().saturating_sub(1));
     let Some(tab) = props.tabs.get(index) else {
         return html! {};
@@ -113,15 +160,17 @@ pub fn breakdown_panel(props: &BreakdownPanelProps) -> Html {
         }
     });
 
-    // Dimension tabs carry no events at all; when the Events metric is active
-    // there, fall back to page views for the *whole tab* (mixing real event
-    // counts with pageview fallbacks per-row would rank apples against
-    // oranges). Tabs with any real events display true event counts.
+    // Most dimension tabs carry no events at all; when the Events metric is
+    // active there, fall back to page views for the *whole tab* (mixing real
+    // event counts with pageview fallbacks per-row would rank apples against
+    // oranges). The Events tab is the mirror image — its rows carry nothing
+    // *but* events — so a view metric falls back to event counts there.
     let tab_has_events = tab.rows.iter().any(|r| r.events > 0);
-    let metric = if props.metric == Metric::Events && !tab_has_events {
-        Metric::Pageviews
-    } else {
-        props.metric
+    let tab_has_views = tab.rows.iter().any(|r| r.pageviews > 0 || r.visitors > 0);
+    let metric = match props.metric {
+        Metric::Events if !tab_has_events => Metric::Pageviews,
+        m if m != Metric::Events && !tab_has_views && tab_has_events => Metric::Events,
+        m => m,
     };
     // The API orders rows by pageviews; re-rank by whichever metric is displayed.
     let mut ranked: Vec<&PanelRow> = tab.rows.iter().collect();
@@ -168,13 +217,14 @@ pub fn breakdown_panel(props: &BreakdownPanelProps) -> Html {
         };
         // The action is a sibling of the row button (never a child — nested
         // interactive elements are invalid HTML and confuse assistive tech),
-        // absolutely positioned over the row's end on hover.
-        let action = tab.action.as_ref().map(|action| {
+        // absolutely positioned over the row's end on hover. Sentinel rows
+        // aggregate absent values, which no detail page can address.
+        let action = tab.action.as_ref().filter(|_| !row.value.is_empty()).map(|action| {
             let (action, value) = (action.clone(), row.value.clone());
             let onclick = Callback::from(move |_: MouseEvent| action.emit(value.clone()));
             html! {
                 <button class="brow__action" title={tab.action_title} onclick={onclick}>
-                    { icons::gear() }
+                    { tab.action_icon.render() }
                 </button>
             }
         });

--- a/ui/src/components/distribution.rs
+++ b/ui/src/components/distribution.rs
@@ -1,0 +1,44 @@
+//! One distribution card: proportional bars over a dimension's values, shared
+//! by the exception and event detail pages.
+
+use analytics_api::CountRow;
+use yew::prelude::*;
+
+use crate::format::compact;
+
+/// Render a distribution card. Cards whose only row is the absent sentinel
+/// carry no signal and are dropped.
+pub fn distribution(title: &str, rows: &[CountRow], total: i64) -> Html {
+    let informative = rows.iter().any(|r| !r.key.is_empty());
+    if rows.is_empty() || !informative {
+        return html! {};
+    }
+    let max = rows.iter().map(|r| r.count).max().unwrap_or(1).max(1);
+    let total = total.max(1);
+    let bars = rows.iter().map(|row| {
+        let share = row.count as f64 / total as f64 * 100.0;
+        let width = row.count as f64 / max as f64 * 100.0;
+        let label = if row.key.is_empty() {
+            "Unknown".to_string()
+        } else {
+            row.key.clone()
+        };
+        html! {
+            <li class="dist__row" key={row.key.clone()}>
+                <span class="dist__bar" style={format!("width: {width:.1}%")} />
+                <span class={classes!("dist__label", row.key.is_empty().then_some("brow__text--absent"))}
+                    title={label.clone()}>
+                    { label }
+                </span>
+                <span class="dist__share">{ format!("{share:.0}%") }</span>
+                <span class="dist__count">{ compact(row.count) }</span>
+            </li>
+        }
+    });
+    html! {
+        <section class="dist">
+            <h3 class="dist__title">{ title.to_string() }</h3>
+            <ul class="dist__rows">{ for bars }</ul>
+        </section>
+    }
+}

--- a/ui/src/components/icons.rs
+++ b/ui/src/components/icons.rs
@@ -139,6 +139,16 @@ pub fn check() -> Html {
     })
 }
 
+/// A bell (the unmute action: surface this group again).
+pub fn bell() -> Html {
+    icon(html! {
+        <>
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+        </>
+    })
+}
+
 /// A muted bell (the ignore action).
 pub fn mute() -> Html {
     icon(html! {

--- a/ui/src/components/icons.rs
+++ b/ui/src/components/icons.rs
@@ -132,6 +132,37 @@ pub fn chevron_right() -> Html {
     })
 }
 
+/// A checkmark (the resolve action).
+pub fn check() -> Html {
+    icon(html! {
+        <polyline points="20 6 9 17 4 12" />
+    })
+}
+
+/// A muted bell (the ignore action).
+pub fn mute() -> Html {
+    icon(html! {
+        <>
+            <path d="M8.7 3a6 6 0 0 1 9.3 5c0 3.2.6 5.3 1.3 6.7" />
+            <path d="M17 17H3s3-2 3-9a6 6 0 0 1 .3-1.9" />
+            <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+            <line x1="2" y1="2" x2="22" y2="22" />
+        </>
+    })
+}
+
+/// A checkmark struck through (the reopen action: un-resolve). The strike
+/// carries its own class so the button can colour it independently of the
+/// checkmark.
+pub fn check_struck() -> Html {
+    icon(html! {
+        <>
+            <polyline points="20 6 9 17 4 12" />
+            <line class="icon-strike" x1="4" y1="5" x2="20" y2="21" />
+        </>
+    })
+}
+
 pub fn chevron_left() -> Html {
     icon(html! {
         <polyline points="15 18 9 12 15 6" />

--- a/ui/src/components/mod.rs
+++ b/ui/src/components/mod.rs
@@ -2,6 +2,7 @@ mod alert;
 mod app_bar;
 mod breakdown;
 pub mod charts;
+mod distribution;
 mod drawer;
 mod dropdown;
 mod error;
@@ -19,8 +20,9 @@ mod trace_list;
 
 pub use alert::{Alert, AlertKind};
 pub use app_bar::AppBar;
-pub use breakdown::{BreakdownPanel, PanelRow, PanelTab};
+pub use breakdown::{ActionIcon, BreakdownPanel, PanelRow, PanelTab};
 pub use charts::{Sparkline, TimeSeriesChart};
+pub use distribution::distribution;
 pub use drawer::Drawer;
 pub use dropdown::{Dropdown, DropdownItem};
 pub use error::ApiErrorAlert;

--- a/ui/src/filters.rs
+++ b/ui/src/filters.rs
@@ -47,10 +47,13 @@ pub enum Dim {
     UtmMedium,
     UtmCampaign,
     AppVersion,
+    /// The name of a custom/pixel event (page views carry none, so an event
+    /// filter scopes the view to those events).
+    EventName,
 }
 
 impl Dim {
-    pub const ALL: [Dim; 14] = [
+    pub const ALL: [Dim; 15] = [
         Dim::Project,
         Dim::Source,
         Dim::Path,
@@ -65,6 +68,7 @@ impl Dim {
         Dim::UtmMedium,
         Dim::UtmCampaign,
         Dim::AppVersion,
+        Dim::EventName,
     ];
 
     /// The field name used in filter expressions.
@@ -84,6 +88,7 @@ impl Dim {
             Dim::UtmMedium => "utm_medium",
             Dim::UtmCampaign => "utm_campaign",
             Dim::AppVersion => "app_version",
+            Dim::EventName => "event",
         }
     }
 
@@ -111,6 +116,7 @@ impl Dim {
             Dim::UtmMedium => "UTM medium",
             Dim::UtmCampaign => "UTM campaign",
             Dim::AppVersion => "App version",
+            Dim::EventName => "Event",
         }
     }
 
@@ -119,6 +125,7 @@ impl Dim {
         match self {
             Dim::Referrer => "Direct / none",
             Dim::UtmSource | Dim::UtmMedium | Dim::UtmCampaign => "None",
+            Dim::EventName => "Unnamed",
             _ => "Unknown",
         }
     }
@@ -174,6 +181,7 @@ const DASHBOARD_FIELDS: &[&str] = &[
     "utm_source",
     "utm_medium",
     "utm_campaign",
+    "event",
 ];
 
 /// A relative lookback preset. Presets stay relative in the URL (`range=7d`), so
@@ -861,6 +869,15 @@ fn decode(value: &str) -> String {
         .unwrap_or_else(|_| value.to_string())
 }
 
+/// The decoded value of a single query-string parameter, for the page-identity
+/// keys (`name`, `source`) that ride alongside the filter state.
+pub fn query_param(query_str: &str, key: &str) -> Option<String> {
+    pairs_of(query_str)
+        .into_iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v)
+}
+
 fn encode_pairs(pairs: &[(String, String)]) -> String {
     pairs
         .iter()
@@ -906,5 +923,16 @@ pub fn use_navigate_with_filters() -> Callback<(Route, FilterSet)> {
     Callback::from(move |(route, filters): (Route, FilterSet)| {
         let Some(navigator) = &navigator else { return };
         let _ = navigator.push_with_query(&route, &filters.to_pairs());
+    })
+}
+
+/// Navigate to `route` with explicit query pairs — the filter state plus a
+/// page-identity key like an event `name` or exception `source`.
+#[hook]
+pub fn use_navigate_with_query() -> Callback<(Route, Vec<(String, String)>)> {
+    let navigator = use_navigator();
+    Callback::from(move |(route, pairs): (Route, Vec<(String, String)>)| {
+        let Some(navigator) = &navigator else { return };
+        let _ = navigator.push_with_query(&route, &pairs);
     })
 }

--- a/ui/src/pages/dashboard.rs
+++ b/ui/src/pages/dashboard.rs
@@ -10,12 +10,14 @@ use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
 use crate::api::{self, ApiError};
+use crate::app::Route;
 use crate::components::charts::Metric;
 use crate::components::{
-    ApiErrorAlert, BreakdownPanel, Dropdown, DropdownItem, FilterBar, MetricCards, PageHeader,
-    PanelRow, PanelTab, ProjectDrawer, ProjectsContext, SuggestOption, TimeSeriesChart, TraceList,
+    ActionIcon, ApiErrorAlert, BreakdownPanel, Dropdown, DropdownItem, FilterBar, MetricCards,
+    PageHeader, PanelRow, PanelTab, ProjectDrawer, ProjectsContext, SuggestOption, TimeSeriesChart,
+    TraceList,
 };
-use crate::filters::{Dim, TimeRange, use_apply_filters, use_filters};
+use crate::filters::{Dim, TimeRange, use_apply_filters, use_filters, use_navigate_with_query};
 use crate::format::{country_flag, country_name, group_thousands, language_name};
 
 #[function_component(Dashboard)]
@@ -132,6 +134,17 @@ pub fn dashboard() -> Html {
     let close_manage = {
         let manage_project = manage_project.clone();
         Callback::from(move |_: ()| manage_project.set(None))
+    };
+    // Open an event's detail view, carrying the filter state so its numbers
+    // cover the same slice as the row that was clicked.
+    let open_event = {
+        let navigate = use_navigate_with_query();
+        let filters = filters.clone();
+        Callback::from(move |name: String| {
+            let mut pairs = filters.to_pairs();
+            pairs.push(("name".into(), name));
+            navigate.emit((Route::Event, pairs));
+        })
     };
     let bump = {
         let reload = reload.clone();
@@ -271,11 +284,20 @@ pub fn dashboard() -> Html {
             // site/app is this?" is the first drill-down an operator reaches
             // for. Projects (which merely group sources) sit last.
             let source_tabs = vec![PanelTab::new("Sources", Dim::Source, source_rows)];
-            let pages_tabs = vec![PanelTab::new(
-                "Top pages",
-                Dim::Path,
-                plain(&dash.breakdowns.pages, "Unknown"),
-            )];
+            let pages_tabs = vec![
+                PanelTab::new(
+                    "Top pages",
+                    Dim::Path,
+                    plain(&dash.breakdowns.pages, "Unknown"),
+                ),
+                PanelTab::new(
+                    "Events",
+                    Dim::EventName,
+                    plain(&dash.breakdowns.event_names, Dim::EventName.absent_label()),
+                )
+                .with_action("View event details", open_event.clone())
+                .with_action_icon(ActionIcon::Open),
+            ];
             let acquisition_tabs = vec![
                 PanelTab::new(
                     "Referrers",
@@ -362,7 +384,10 @@ pub fn dashboard() -> Html {
                     </div>
                     <div class="panel-grid">
                         <BreakdownPanel tabs={source_tabs} metric={*metric} on_filter={on_filter.clone()} active={active.clone()} />
-                        <BreakdownPanel tabs={pages_tabs} metric={*metric} on_filter={on_filter.clone()} active={active.clone()} />
+                        // Follows the metric: Events mode surfaces the event-name
+                        // histogram, the view metrics bring Top pages back.
+                        <BreakdownPanel tabs={pages_tabs} metric={*metric} on_filter={on_filter.clone()} active={active.clone()}
+                            select_tab={Some(if *metric == Metric::Events { 1 } else { 0 })} />
                         <BreakdownPanel tabs={acquisition_tabs} metric={*metric} on_filter={on_filter.clone()} active={active.clone()} />
                         <BreakdownPanel tabs={location_tabs} metric={*metric} on_filter={on_filter.clone()} active={active.clone()} />
                         <BreakdownPanel tabs={platform_tabs} metric={*metric} on_filter={on_filter.clone()} active={active.clone()} />
@@ -443,6 +468,10 @@ fn build_suggestions(
                 .collect(),
         ),
         (Dim::Path, rows(&dash.breakdowns.pages, "Unknown")),
+        (
+            Dim::EventName,
+            rows(&dash.breakdowns.event_names, Dim::EventName.absent_label()),
+        ),
         (
             Dim::Referrer,
             rows(&dash.breakdowns.referrers, Dim::Referrer.absent_label()),

--- a/ui/src/pages/event_detail.rs
+++ b/ui/src/pages/event_detail.rs
@@ -1,0 +1,280 @@
+//! One custom/pixel event in forensic detail, modelled on the exception view:
+//! the occurrence trend, how the event distributes across key dimensions
+//! (source, page, application, …), a scrubber over its **distinct metadata
+//! variants** — one representative example per unique reporter payload — and
+//! the session traces it occurred in.
+//!
+//! The event name rides in the query string (`?name=…`) alongside the filter
+//! state, because names are reporter-chosen free text that must not break the
+//! router; the filters scope the numbers to the same slice as the dashboard
+//! panel that linked here.
+
+use analytics_api::{CountRow, EventDetail as EventDetailData, EventVariant, source_label};
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+use yew_router::prelude::use_location;
+
+use crate::api::{self, ApiError};
+use crate::app::Route;
+use crate::components::metadata::Metadata;
+use crate::components::{
+    ApiErrorAlert, Crumb, PageHeader, Sparkline, TraceList, distribution, icons,
+};
+use crate::filters::{query_param, use_filters, use_navigate_with_filters};
+use crate::format::{
+    ago, country_flag, country_name, group_thousands, language_name, short_session_id,
+};
+
+#[function_component(EventDetail)]
+pub fn event_detail() -> Html {
+    let location = use_location();
+    let name = location
+        .as_ref()
+        .and_then(|l| query_param(l.query_str(), "name"))
+        .unwrap_or_default();
+    let detail = use_state(|| None::<Result<EventDetailData, ApiError>>);
+    // The panel row that linked here carried the dashboard's filter state, so
+    // the detail numbers cover the same slice the operator was looking at.
+    let filters = use_filters();
+    let range_label = filters.range_label();
+
+    {
+        let detail = detail.clone();
+        let name = name.clone();
+        let filters = filters.clone();
+        use_effect_with((name.clone(), filters.canonical()), move |_| {
+            if !name.is_empty() {
+                let query = filters.stats_query(js_sys::Date::now() as i64);
+                spawn_local(async move {
+                    detail.set(Some(api::event_detail(&name, &query).await));
+                });
+            }
+            || ()
+        });
+    }
+
+    let title = if name.is_empty() {
+        "Event".to_string()
+    } else {
+        name.clone()
+    };
+    let crumbs = vec![
+        Crumb::link_with_query("Dashboard", Route::Overview, filters.to_pairs()),
+        Crumb::current(title.clone()),
+    ];
+
+    let body = if name.is_empty() {
+        html! {
+            <ApiErrorAlert error={ApiError::Server(
+                "No event was specified — open this page from the dashboard's Events panel.".into()
+            )} />
+        }
+    } else {
+        match &*detail {
+            None => html! { <div class="page-loading">{ "Loading…" }</div> },
+            Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
+            Some(Ok(detail)) => {
+                let meta = format!(
+                    "{} occurrences · first seen {} · last seen {}",
+                    group_thousands(detail.count),
+                    ago(detail.first_seen_ms),
+                    ago(detail.last_seen_ms),
+                );
+                html! {
+                    <>
+                        <div class="exc-head panel">
+                            <div class="exc-head__top">
+                                <span class="badge badge--brand">{ "Event" }</span>
+                                <span class="exc-head__title">
+                                    <b class="exc-head__type">{ &detail.name }</b>
+                                </span>
+                            </div>
+                            <div class="exc-head__meta muted">{ meta }</div>
+                            if !detail.trend.is_empty() {
+                                <div class="exc-head__trend">
+                                    <span class="stat__label">{ range_label.clone() }</span>
+                                    <Sparkline points={detail.trend.clone()} class={classes!("exc-head__spark", "exc-head__spark--brand")} />
+                                </div>
+                            }
+                        </div>
+
+                        <h2 class="section__title">{ "Distribution" }</h2>
+                        // Brand-tinted bars: event volume is traffic, not trouble.
+                        <div class="dist-grid dist-grid--brand">
+                            { distribution("Apps / sources", &sources_named(&detail.breakdowns.sources), detail.count) }
+                            { distribution("Pages", &detail.breakdowns.pages, detail.count) }
+                            { distribution("Applications", &detail.breakdowns.browsers, detail.count) }
+                            { distribution("Operating systems", &detail.breakdowns.operating_systems, detail.count) }
+                            { distribution("Devices", &detail.breakdowns.devices, detail.count) }
+                            { distribution("Countries", &countries_named(&detail.breakdowns.countries), detail.count) }
+                            { distribution("Languages", &languages_named(&detail.breakdowns.languages), detail.count) }
+                        </div>
+
+                        <VariantScrubber variants={detail.variants.clone()} key={detail.name.clone()} />
+                        // Pick which of the event's sessions to inspect.
+                        <TraceList
+                            traces={detail.traces.clone()}
+                            hint="Sessions this event occurred in"
+                        />
+                    </>
+                }
+            }
+        }
+    };
+
+    html! {
+        <div class="page">
+            <PageHeader crumbs={crumbs} title={title} />
+            { body }
+        </div>
+    }
+}
+
+/// Source rows re-keyed by their display label (URIs are read as bare names
+/// throughout the UI).
+fn sources_named(rows: &[CountRow]) -> Vec<CountRow> {
+    rows.iter()
+        .map(|r| CountRow {
+            key: if r.key.is_empty() {
+                String::new()
+            } else {
+                source_label(&r.key).to_string()
+            },
+            count: r.count,
+        })
+        .collect()
+}
+
+/// Country rows re-keyed as `flag name` (codes are for machines).
+fn countries_named(rows: &[CountRow]) -> Vec<CountRow> {
+    rows.iter()
+        .map(|r| CountRow {
+            key: if r.key.is_empty() {
+                String::new()
+            } else {
+                match country_flag(&r.key) {
+                    Some(flag) => format!("{flag} {}", country_name(&r.key)),
+                    None => country_name(&r.key),
+                }
+            },
+            count: r.count,
+        })
+        .collect()
+}
+
+/// Language rows re-keyed by their display name.
+fn languages_named(rows: &[CountRow]) -> Vec<CountRow> {
+    rows.iter()
+        .map(|r| CountRow {
+            key: if r.key.is_empty() {
+                String::new()
+            } else {
+                language_name(&r.key)
+            },
+            count: r.count,
+        })
+        .collect()
+}
+
+#[derive(Properties, PartialEq)]
+struct VariantScrubberProps {
+    variants: Vec<EventVariant>,
+}
+
+/// Scrub through the event's distinct examples with ‹ › navigation; each shows
+/// how many occurrences share its exact metadata.
+#[function_component(VariantScrubber)]
+fn variant_scrubber(props: &VariantScrubberProps) -> Html {
+    let index = use_state(|| 0usize);
+    let filters = use_filters();
+    let navigate = use_navigate_with_filters();
+    let count = props.variants.len();
+    if count == 0 {
+        return html! {};
+    }
+    let i = (*index).min(count - 1);
+    let variant = &props.variants[i];
+
+    let go = |delta: i64| {
+        let index = index.clone();
+        Callback::from(move |_: MouseEvent| {
+            let next = (i as i64 + delta).rem_euclid(count as i64) as usize;
+            index.set(next);
+        })
+    };
+
+    let ua = match (&variant.ua_browser, &variant.ua_os) {
+        (Some(b), Some(os)) => format!("{b} on {os}"),
+        (Some(b), None) => b.clone(),
+        (None, Some(os)) => os.clone(),
+        _ => "unknown client".to_string(),
+    };
+    // Where the exemplar fired: source plus the page, when reported.
+    let fired_at = variant.source.as_ref().map(|source| {
+        format!(
+            "{}{}",
+            source_label(source),
+            variant.pathname.as_deref().unwrap_or("")
+        )
+    });
+    let metadata = Metadata::parse(variant.metadata.as_deref());
+
+    // Jump to the session this exemplar occurred in, when it reported one.
+    let trace_link = variant.session_id.as_ref().map(|sid| {
+        let onclick = {
+            let (navigate, filters) = (navigate.clone(), filters.clone());
+            let id = sid.clone();
+            Callback::from(move |_: MouseEvent| {
+                navigate.emit((Route::Trace { id: id.clone() }, filters.clone()));
+            })
+        };
+        html! {
+            <button class="btn btn--small" onclick={onclick}
+                title={format!("Open session {}", short_session_id(sid))}>
+                { "View session trace" }
+            </button>
+        }
+    });
+
+    html! {
+        <>
+            <div class="section__title exc-variants__head">
+                <h2 class="section__title">{ "Distinct examples" }</h2>
+                <div class="exc-variants__nav">
+                    <button class="btn btn--small" onclick={go(-1)} disabled={count <= 1}
+                        aria-label="Previous example">
+                        { icons::chevron_left() }
+                    </button>
+                    <span class="exc-variants__pos">{ format!("{} of {}", i + 1, count) }</span>
+                    <button class="btn btn--small" onclick={go(1)} disabled={count <= 1}
+                        aria-label="Next example">
+                        { icons::chevron_right() }
+                    </button>
+                </div>
+            </div>
+            <div class="occurrence exc-variant">
+                <div class="occurrence__meta">
+                    <span class="badge badge--brand" title="Occurrences sharing this exact metadata">
+                        { format!("×{} occurrence{}", group_thousands(variant.count), if variant.count == 1 { "" } else { "s" }) }
+                    </span>
+                    <span>{ ua }</span>
+                    if let Some(fired_at) = fired_at {
+                        <span class="exc-variant__app"><code>{ fired_at }</code></span>
+                    }
+                    <span class="muted">{ format!("last seen {}", ago(variant.last_seen_ms)) }</span>
+                    // Set apart from the descriptive metadata, at the row's end.
+                    <span class="occurrence__actions">{ trace_link }</span>
+                </div>
+                if !metadata.tags.is_empty() {
+                    <div class="occurrence__message">
+                        { metadata.tag_pills() }
+                    </div>
+                }
+                { metadata.context_list() }
+                if metadata.tags.is_empty() && metadata.context.is_empty() && metadata.raw.is_none() {
+                    <div class="occurrence__message muted">{ "No metadata reported." }</div>
+                }
+            </div>
+        </>
+    }
+}

--- a/ui/src/pages/exception_detail.rs
+++ b/ui/src/pages/exception_detail.rs
@@ -3,20 +3,28 @@
 //! application, …), and a scrubber over the group's **distinct variants** — one
 //! representative example per unique message/stack, with a count of the
 //! occurrences it stands for.
+//!
+//! A group's identity is source-scoped — fingerprint + the application it was
+//! seen on — carried as a `?source=` query parameter alongside the filter
+//! state. Pre-source deep links (no `source`) fall back to the project-wide
+//! aggregate.
 
 use analytics_api::{
-    CountRow, ExceptionGroupDetail, ExceptionStatus, ExceptionVariant, TriageInput,
+    ExceptionGroupDetail, ExceptionStatus, ExceptionVariant, TriageInput, source_label,
 };
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
+use yew_router::prelude::use_location;
 
 use crate::api::{self, ApiError};
 use crate::app::Route;
 use crate::components::metadata::Metadata;
 use crate::components::status::{status_class, status_label};
-use crate::components::{ApiErrorAlert, Crumb, PageHeader, Sparkline, TraceList, icons};
-use crate::filters::{use_filters, use_navigate_with_filters};
-use crate::format::{ago, compact, group_thousands, short_session_id};
+use crate::components::{
+    ApiErrorAlert, Crumb, PageHeader, Sparkline, TraceList, distribution, icons,
+};
+use crate::filters::{query_param, use_filters, use_navigate_with_filters};
+use crate::format::{ago, group_thousands, short_session_id};
 
 #[derive(Properties, PartialEq)]
 pub struct ExceptionDetailProps {
@@ -27,6 +35,11 @@ pub struct ExceptionDetailProps {
 #[function_component(ExceptionDetail)]
 pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     let (project, group) = (props.project.clone(), props.group.clone());
+    let location = use_location();
+    let source = location
+        .as_ref()
+        .and_then(|l| query_param(l.query_str(), "source"))
+        .filter(|s| !s.trim().is_empty());
     let detail = use_state(|| None::<Result<ExceptionGroupDetail, ApiError>>);
     let reload = use_state(|| 0u32);
     // The row that linked here carried the inbox's filter state, so the detail
@@ -36,7 +49,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
 
     {
         let detail = detail.clone();
-        let (project, group) = (project.clone(), group.clone());
+        let (project, group, source) = (project.clone(), group.clone(), source.clone());
         let filters = filters.clone();
         // `project` is a dependency: two projects can share a fingerprint, so
         // navigating between same-group exceptions across projects must refetch.
@@ -45,7 +58,9 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
             move |_| {
                 let range = filters.range_query(js_sys::Date::now() as i64);
                 spawn_local(async move {
-                    detail.set(Some(api::exception_detail(&group, &project, &range).await));
+                    detail.set(Some(
+                        api::exception_detail(&group, &project, source.as_deref(), &range).await,
+                    ));
                 });
                 || ()
             },
@@ -53,12 +68,18 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     }
 
     let set_status = {
-        let (project, group, reload) = (project.clone(), group.clone(), reload.clone());
+        let (project, group, source, reload) = (
+            project.clone(),
+            group.clone(),
+            source.clone(),
+            reload.clone(),
+        );
         move |status: ExceptionStatus| {
             let input = TriageInput {
                 project_id: project.clone(),
                 status,
                 note: None,
+                source: source.clone(),
             };
             let (group, reload) = (group.clone(), reload.clone());
             Callback::from(move |_: MouseEvent| {
@@ -88,26 +109,47 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
                 match &*detail {
                     None => html! { <div class="page-loading">{ "Loading…" }</div> },
                     Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
-                    Some(Ok(detail)) => html! {
+                    Some(Ok(detail)) => {
+                        let status = detail.group.status;
+                        // Colour + glyph carry the verb; the current state's
+                        // action is a no-op and renders disabled.
+                        let action = |target: ExceptionStatus, class: &'static str, label: &'static str, icon: Html| html! {
+                            <button
+                                class={classes!("exc-action", class)}
+                                title={label}
+                                aria-label={label}
+                                disabled={status == target}
+                                onclick={set_status(target)}
+                            >
+                                { icon }
+                            </button>
+                        };
+                        let meta = format!(
+                            "{} occurrences · first seen {} · last seen {}",
+                            group_thousands(detail.group.count),
+                            ago(detail.group.first_seen_ms),
+                            ago(detail.group.last_seen_ms),
+                        );
+                        let meta = match &source {
+                            Some(source) => format!("{} · {meta}", source_label(source)),
+                            None => meta,
+                        };
+                        html! {
                         <>
                             <div class="exc-head panel">
-                                <div class="exc-head__status">
-                                    <span class={status_class(detail.group.status)}>{ status_label(detail.group.status) }</span>
-                                    <p class="exc-head__message">{ &detail.group.sample_message }</p>
-                                    <div class="exc-head__meta muted">
-                                        { format!(
-                                            "{} occurrences · first seen {} · last seen {}",
-                                            group_thousands(detail.group.count),
-                                            ago(detail.group.first_seen_ms),
-                                            ago(detail.group.last_seen_ms),
-                                        ) }
-                                    </div>
+                                <div class="exc-head__top">
+                                    <span class={status_class(status)}>{ status_label(status) }</span>
+                                    <span class="exc-head__title">
+                                        <b class="exc-head__type">{ &detail.group.exc_type }</b>
+                                        <code class="exc-head__message">{ &detail.group.sample_message }</code>
+                                    </span>
                                     <div class="exc-head__actions">
-                                        <button class="btn" onclick={set_status(ExceptionStatus::Resolved)}>{ "Mark resolved" }</button>
-                                        <button class="btn" onclick={set_status(ExceptionStatus::Ignored)}>{ "Ignore" }</button>
-                                        <button class="btn btn--ghost" onclick={set_status(ExceptionStatus::Unresolved)}>{ "Reopen" }</button>
+                                        { action(ExceptionStatus::Resolved, "exc-action--resolve", "Mark resolved", icons::check()) }
+                                        { action(ExceptionStatus::Ignored, "exc-action--ignore", "Ignore", icons::mute()) }
+                                        { action(ExceptionStatus::Unresolved, "exc-action--reopen", "Reopen", icons::check_struck()) }
                                     </div>
                                 </div>
+                                <div class="exc-head__meta muted">{ meta }</div>
                                 if !detail.group.trend.is_empty() {
                                     <div class="exc-head__trend">
                                         <span class="stat__label">{ range_label.clone() }</span>
@@ -119,7 +161,11 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
                             <h2 class="section__title">{ "Distribution" }</h2>
                             <div class="dist-grid">
                                 { distribution("App versions", &detail.breakdowns.app_versions, detail.group.count) }
-                                { distribution("Apps / sources", &detail.breakdowns.sources, detail.group.count) }
+                                // Scoped to one source, the sources card is a
+                                // single 100% row — the header names it instead.
+                                if source.is_none() {
+                                    { distribution("Apps / sources", &detail.breakdowns.sources, detail.group.count) }
+                                }
                                 { distribution("Applications", &detail.breakdowns.browsers, detail.group.count) }
                                 { distribution("Operating systems", &detail.breakdowns.operating_systems, detail.group.count) }
                                 { distribution("Devices", &detail.breakdowns.devices, detail.group.count) }
@@ -127,6 +173,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
 
                             <VariantScrubber
                                 variants={detail.variants.clone()}
+                                scoped={source.is_some()}
                                 key={detail.group.group_id.clone()}
                             />
                             // Pick which of the group's sessions to inspect.
@@ -135,6 +182,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
                                 hint="Sessions this exception occurred in"
                             />
                         </>
+                        }
                     },
                 }
             }
@@ -142,42 +190,13 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     }
 }
 
-/// One distribution card: proportional bars over a dimension's values. Cards
-/// whose only row is the absent sentinel carry no signal and are dropped.
-fn distribution(title: &str, rows: &[CountRow], total: i64) -> Html {
-    let informative = rows.iter().any(|r| !r.key.is_empty());
-    if rows.is_empty() || !informative {
-        return html! {};
-    }
-    let max = rows.iter().map(|r| r.count).max().unwrap_or(1).max(1);
-    let total = total.max(1);
-    let bars = rows.iter().map(|row| {
-        let share = row.count as f64 / total as f64 * 100.0;
-        let width = row.count as f64 / max as f64 * 100.0;
-        let label = if row.key.is_empty() { "Unknown".to_string() } else { row.key.clone() };
-        html! {
-            <li class="dist__row" key={row.key.clone()}>
-                <span class="dist__bar" style={format!("width: {width:.1}%")} />
-                <span class={classes!("dist__label", row.key.is_empty().then_some("brow__text--absent"))}
-                    title={label.clone()}>
-                    { label }
-                </span>
-                <span class="dist__share">{ format!("{share:.0}%") }</span>
-                <span class="dist__count">{ compact(row.count) }</span>
-            </li>
-        }
-    });
-    html! {
-        <section class="dist">
-            <h3 class="dist__title">{ title.to_string() }</h3>
-            <ul class="dist__rows">{ for bars }</ul>
-        </section>
-    }
-}
-
 #[derive(Properties, PartialEq)]
 struct VariantScrubberProps {
     variants: Vec<ExceptionVariant>,
+    /// Whether the view is scoped to one source — the application is then
+    /// given, so releases read as bare version numbers.
+    #[prop_or_default]
+    scoped: bool,
 }
 
 /// Scrub through a group's distinct examples with ‹ › navigation; each shows
@@ -208,14 +227,22 @@ fn variant_scrubber(props: &VariantScrubberProps) -> Html {
         (None, Some(os)) => os.clone(),
         _ => "unknown client".to_string(),
     };
-    // The source is the application; pair it with the reported release.
-    let app = variant.source.as_ref().map(|source| {
-        let label = analytics_api::source_label(source).to_string();
-        match &variant.app_version {
-            Some(version) => format!("{label} @ {version}"),
-            None => label,
-        }
-    });
+    // The source is the application; pair it with the reported release. In a
+    // source-scoped view the application is given, so the release stands alone.
+    let app = if props.scoped {
+        variant
+            .app_version
+            .as_ref()
+            .map(|version| format!("v{version}"))
+    } else {
+        variant.source.as_ref().map(|source| {
+            let label = source_label(source).to_string();
+            match &variant.app_version {
+                Some(version) => format!("{label} @ {version}"),
+                None => label,
+            }
+        })
+    };
     let metadata = Metadata::parse(variant.metadata.as_deref());
 
     // Jump to the session this exemplar occurred in, when it reported one.

--- a/ui/src/pages/exception_detail.rs
+++ b/ui/src/pages/exception_detail.rs
@@ -6,8 +6,7 @@
 //!
 //! A group's identity is source-scoped — fingerprint + the application it was
 //! seen on — carried as a `?source=` query parameter alongside the filter
-//! state. Pre-source deep links (no `source`) fall back to the project-wide
-//! aggregate.
+//! state.
 
 use analytics_api::{
     ExceptionGroupDetail, ExceptionStatus, ExceptionVariant, TriageInput, source_label,
@@ -35,11 +34,14 @@ pub struct ExceptionDetailProps {
 #[function_component(ExceptionDetail)]
 pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     let (project, group) = (props.project.clone(), props.group.clone());
+    // The source is part of the group's identity (the same fingerprint on two
+    // applications is two independent failures); a link without one is broken.
     let location = use_location();
     let source = location
         .as_ref()
         .and_then(|l| query_param(l.query_str(), "source"))
-        .filter(|s| !s.trim().is_empty());
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     let detail = use_state(|| None::<Result<ExceptionGroupDetail, ApiError>>);
     let reload = use_state(|| 0u32);
     // The row that linked here carried the inbox's filter state, so the detail
@@ -56,13 +58,15 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
         use_effect_with(
             (project.clone(), group.clone(), filters.canonical(), *reload),
             move |_| {
+                let Some(source) = source else {
+                    return;
+                };
                 let range = filters.range_query(js_sys::Date::now() as i64);
                 spawn_local(async move {
                     detail.set(Some(
-                        api::exception_detail(&group, &project, source.as_deref(), &range).await,
+                        api::exception_detail(&group, &project, &source, &range).await,
                     ));
                 });
-                || ()
             },
         );
     }
@@ -79,7 +83,7 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
                 project_id: project.clone(),
                 status,
                 note: None,
-                source: source.clone(),
+                source: source.clone().unwrap_or_default(),
             };
             let (group, reload) = (group.clone(), reload.clone());
             Callback::from(move |_: MouseEvent| {
@@ -102,90 +106,125 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
         Crumb::current(title.clone()),
     ];
 
+    let body = match (&source, &*detail) {
+        (None, _) => html! {
+            <ApiErrorAlert error={ApiError::Server(
+                "This exception link is missing its source — open the group from the Exceptions inbox.".into()
+            )} />
+        },
+        (Some(_), None) => html! { <div class="page-loading">{ "Loading…" }</div> },
+        (Some(_), Some(Err(err))) => html! { <ApiErrorAlert error={err.clone()} /> },
+        (Some(source), Some(Ok(detail))) => {
+            let status = detail.group.status;
+            // Colour + glyph carry the verb. Only the transitions that apply
+            // to the current state are offered: an open group can be resolved
+            // or muted; a triaged one reopened (or re-routed to the other
+            // triaged state).
+            let action =
+                |target: ExceptionStatus, class: &'static str, label: &'static str, icon: Html| {
+                    html! {
+                        <button
+                            class={classes!("exc-action", class)}
+                            title={label}
+                            aria-label={label}
+                            onclick={set_status(target)}
+                        >
+                            { icon }
+                        </button>
+                    }
+                };
+            let resolve = || {
+                action(
+                    ExceptionStatus::Resolved,
+                    "exc-action--resolve",
+                    "Mark resolved",
+                    icons::check(),
+                )
+            };
+            let mute = || {
+                action(
+                    ExceptionStatus::Ignored,
+                    "exc-action--ignore",
+                    "Mute",
+                    icons::mute(),
+                )
+            };
+            let reopen = || {
+                action(
+                    ExceptionStatus::Unresolved,
+                    "exc-action--reopen",
+                    "Reopen",
+                    icons::check_struck(),
+                )
+            };
+            let unmute = || {
+                action(
+                    ExceptionStatus::Unresolved,
+                    "exc-action--ignore",
+                    "Unmute",
+                    icons::bell(),
+                )
+            };
+            let actions = match status {
+                ExceptionStatus::Unresolved => html! { <>{ resolve() }{ mute() }</> },
+                ExceptionStatus::Resolved => html! { <>{ reopen() }{ mute() }</> },
+                ExceptionStatus::Ignored => html! { <>{ resolve() }{ unmute() }</> },
+            };
+            let meta = format!(
+                "{} · {} occurrences · first seen {} · last seen {}",
+                source_label(source),
+                group_thousands(detail.group.count),
+                ago(detail.group.first_seen_ms),
+                ago(detail.group.last_seen_ms),
+            );
+            html! {
+                <>
+                    <div class="exc-head panel">
+                        <div class="exc-head__top">
+                            <span class={status_class(status)}>{ status_label(status) }</span>
+                            <span class="exc-head__title">
+                                <b class="exc-head__type">{ &detail.group.exc_type }</b>
+                                <code class="exc-head__message">{ &detail.group.sample_message }</code>
+                            </span>
+                            <div class="exc-head__actions" role="group" aria-label="Triage">
+                                { actions }
+                            </div>
+                        </div>
+                        <div class="exc-head__meta muted">{ meta }</div>
+                        if !detail.group.trend.is_empty() {
+                            <div class="exc-head__trend">
+                                <span class="stat__label">{ range_label.clone() }</span>
+                                <Sparkline points={detail.group.trend.clone()} class={classes!("exc-head__spark")} />
+                            </div>
+                        }
+                    </div>
+
+                    <h2 class="section__title">{ "Distribution" }</h2>
+                    <div class="dist-grid">
+                        { distribution("App versions", &detail.breakdowns.app_versions, detail.group.count) }
+                        { distribution("Applications", &detail.breakdowns.browsers, detail.group.count) }
+                        { distribution("Operating systems", &detail.breakdowns.operating_systems, detail.group.count) }
+                        { distribution("Devices", &detail.breakdowns.devices, detail.group.count) }
+                    </div>
+
+                    <VariantScrubber
+                        variants={detail.variants.clone()}
+                        key={detail.group.group_id.clone()}
+                    />
+                    // Pick which of the group's sessions to inspect.
+                    <TraceList
+                        traces={detail.traces.clone()}
+                        hint="Sessions this exception occurred in"
+                    />
+                </>
+            }
+        }
+    };
+
     html! {
         <div class="page">
             <PageHeader crumbs={crumbs} title={title} />
-            {
-                match &*detail {
-                    None => html! { <div class="page-loading">{ "Loading…" }</div> },
-                    Some(Err(err)) => html! { <ApiErrorAlert error={err.clone()} /> },
-                    Some(Ok(detail)) => {
-                        let status = detail.group.status;
-                        // Colour + glyph carry the verb; the current state's
-                        // action is a no-op and renders disabled.
-                        let action = |target: ExceptionStatus, class: &'static str, label: &'static str, icon: Html| html! {
-                            <button
-                                class={classes!("exc-action", class)}
-                                title={label}
-                                aria-label={label}
-                                disabled={status == target}
-                                onclick={set_status(target)}
-                            >
-                                { icon }
-                            </button>
-                        };
-                        let meta = format!(
-                            "{} occurrences · first seen {} · last seen {}",
-                            group_thousands(detail.group.count),
-                            ago(detail.group.first_seen_ms),
-                            ago(detail.group.last_seen_ms),
-                        );
-                        let meta = match &source {
-                            Some(source) => format!("{} · {meta}", source_label(source)),
-                            None => meta,
-                        };
-                        html! {
-                        <>
-                            <div class="exc-head panel">
-                                <div class="exc-head__top">
-                                    <span class={status_class(status)}>{ status_label(status) }</span>
-                                    <span class="exc-head__title">
-                                        <b class="exc-head__type">{ &detail.group.exc_type }</b>
-                                        <code class="exc-head__message">{ &detail.group.sample_message }</code>
-                                    </span>
-                                    <div class="exc-head__actions">
-                                        { action(ExceptionStatus::Resolved, "exc-action--resolve", "Mark resolved", icons::check()) }
-                                        { action(ExceptionStatus::Ignored, "exc-action--ignore", "Ignore", icons::mute()) }
-                                        { action(ExceptionStatus::Unresolved, "exc-action--reopen", "Reopen", icons::check_struck()) }
-                                    </div>
-                                </div>
-                                <div class="exc-head__meta muted">{ meta }</div>
-                                if !detail.group.trend.is_empty() {
-                                    <div class="exc-head__trend">
-                                        <span class="stat__label">{ range_label.clone() }</span>
-                                        <Sparkline points={detail.group.trend.clone()} class={classes!("exc-head__spark")} />
-                                    </div>
-                                }
-                            </div>
-
-                            <h2 class="section__title">{ "Distribution" }</h2>
-                            <div class="dist-grid">
-                                { distribution("App versions", &detail.breakdowns.app_versions, detail.group.count) }
-                                // Scoped to one source, the sources card is a
-                                // single 100% row — the header names it instead.
-                                if source.is_none() {
-                                    { distribution("Apps / sources", &detail.breakdowns.sources, detail.group.count) }
-                                }
-                                { distribution("Applications", &detail.breakdowns.browsers, detail.group.count) }
-                                { distribution("Operating systems", &detail.breakdowns.operating_systems, detail.group.count) }
-                                { distribution("Devices", &detail.breakdowns.devices, detail.group.count) }
-                            </div>
-
-                            <VariantScrubber
-                                variants={detail.variants.clone()}
-                                scoped={source.is_some()}
-                                key={detail.group.group_id.clone()}
-                            />
-                            // Pick which of the group's sessions to inspect.
-                            <TraceList
-                                traces={detail.traces.clone()}
-                                hint="Sessions this exception occurred in"
-                            />
-                        </>
-                        }
-                    },
-                }
-            }
+            { body }
         </div>
     }
 }
@@ -193,10 +232,6 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
 #[derive(Properties, PartialEq)]
 struct VariantScrubberProps {
     variants: Vec<ExceptionVariant>,
-    /// Whether the view is scoped to one source — the application is then
-    /// given, so releases read as bare version numbers.
-    #[prop_or_default]
-    scoped: bool,
 }
 
 /// Scrub through a group's distinct examples with ‹ › navigation; each shows
@@ -227,22 +262,11 @@ fn variant_scrubber(props: &VariantScrubberProps) -> Html {
         (None, Some(os)) => os.clone(),
         _ => "unknown client".to_string(),
     };
-    // The source is the application; pair it with the reported release. In a
-    // source-scoped view the application is given, so the release stands alone.
-    let app = if props.scoped {
-        variant
-            .app_version
-            .as_ref()
-            .map(|version| format!("v{version}"))
-    } else {
-        variant.source.as_ref().map(|source| {
-            let label = source_label(source).to_string();
-            match &variant.app_version {
-                Some(version) => format!("{label} @ {version}"),
-                None => label,
-            }
-        })
-    };
+    // The view is scoped to one source, so the reported release stands alone.
+    let app = variant
+        .app_version
+        .as_ref()
+        .map(|version| format!("v{version}"));
     let metadata = Metadata::parse(variant.metadata.as_deref());
 
     // Jump to the session this exemplar occurred in, when it reported one.

--- a/ui/src/pages/exceptions.rs
+++ b/ui/src/pages/exceptions.rs
@@ -18,7 +18,7 @@ use crate::components::status::{status_class, status_label};
 use crate::components::{
     ApiErrorAlert, FilterBar, PageHeader, ProjectsContext, Sparkline, SuggestOption,
 };
-use crate::filters::{Dim, use_filters, use_navigate_with_filters};
+use crate::filters::{Dim, use_filters, use_navigate_with_query};
 use crate::format::{ago, group_thousands};
 
 thread_local! {
@@ -232,8 +232,17 @@ fn exception_row(e: &GlobalException) -> Html {
                 <div class="exc-row__meta">
                     <span class={status_class(e.group.status)}>{ status_label(e.group.status) }</span>
                     {
+                        // Groups are per source, so the row names the application
+                        // it failed on alongside its owning project.
                         match &e.project_name {
-                            Some(name) => html! { <span class="exc-row__project">{ name.clone() }</span> },
+                            Some(name) => html! {
+                                <>
+                                    <span class="exc-row__project">{ name.clone() }</span>
+                                    <code class="exc-row__source" title={e.source.clone()}>
+                                        { analytics_api::source_label(&e.source) }
+                                    </code>
+                                </>
+                            },
                             None => html! {
                                 <span class="badge badge--muted"
                                     title="This source is not assigned to a project — assign it to enable triage and detail.">
@@ -257,7 +266,11 @@ fn exception_row(e: &GlobalException) -> Html {
     // by project); unassigned rows render inert with an explanatory badge.
     match &e.project_id {
         Some(project) => html! {
-            <ExceptionLink project={project.clone()} group={e.group.group_id.clone()}>
+            <ExceptionLink
+                project={project.clone()}
+                group={e.group.group_id.clone()}
+                source={e.source.clone()}
+            >
                 { row_body }
             </ExceptionLink>
         },
@@ -269,26 +282,34 @@ fn exception_row(e: &GlobalException) -> Html {
 struct ExceptionLinkProps {
     project: String,
     group: String,
+    source: String,
     children: Html,
 }
 
 /// A row that navigates to the exception detail page, carrying the current
-/// filter state so returning to the inbox restores it. Rendered as a
-/// role="button" div (not a `<button>`) because the row contains flow content
-/// and badges, which the button content model forbids.
+/// filter state (so returning to the inbox restores it) plus the row's source
+/// (a group's identity is fingerprint + the application it was seen on).
+/// Rendered as a role="button" div (not a `<button>`) because the row contains
+/// flow content and badges, which the button content model forbids.
 #[function_component(ExceptionLink)]
 fn exception_link(props: &ExceptionLinkProps) -> Html {
     let filters = use_filters();
-    let navigate = use_navigate_with_filters();
+    let navigate = use_navigate_with_query();
     let go = {
-        let (project, group) = (props.project.clone(), props.group.clone());
+        let (project, group, source) = (
+            props.project.clone(),
+            props.group.clone(),
+            props.source.clone(),
+        );
         move || {
+            let mut pairs = filters.to_pairs();
+            pairs.push(("source".into(), source.clone()));
             navigate.emit((
                 Route::Exception {
                     project: project.clone(),
                     group: group.clone(),
                 },
-                filters.clone(),
+                pairs,
             ));
         }
     };

--- a/ui/src/pages/mod.rs
+++ b/ui/src/pages/mod.rs
@@ -1,4 +1,5 @@
 mod dashboard;
+mod event_detail;
 mod exception_detail;
 mod exceptions;
 mod misc;
@@ -7,6 +8,7 @@ mod settings;
 mod trace;
 
 pub use dashboard::Dashboard;
+pub use event_detail::EventDetail;
 pub use exception_detail::ExceptionDetail;
 pub use exceptions::Exceptions;
 pub use misc::{Login, NotFound};

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -44,6 +44,9 @@
   --danger-soft: rgba(237, 106, 100, 0.14);
   --info: #8b92a0;
   --info-soft: rgba(139, 146, 160, 0.14);
+  // Muting/ignoring — a violet distinct from every status colour above.
+  --mute: #a78bfa;
+  --mute-soft: rgba(167, 139, 250, 0.16);
 
   // Charts & breakdown bars.
   --chart-grid: rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## Events on the dashboard

- The **Top pages panel gains an "Events" tab** showing the histogram of custom/pixel event names matching the active filter, backed by a new `event_names` breakdown in the `/api/v1/stats` payload. `event` is now a filterable dimension (`event == "signup"` round-trips as a chip), and the panel's suggestion list includes it.
- **The panel follows the metric selector**: choosing the *Events* metric switches the panel to the Events tab automatically, and switching back to *Page views* (or *Visitors*) restores *Top pages*. Manual tab clicks still work in between. The Events tab also displays event counts even under a view metric (its rows carry nothing else), mirroring the existing events→pageviews fallback.

## Event detail view

A new view modelled on the exception view, reached from a per-row action on the Events tab (`/events?name=…`, name in the query string since event names are free text):

- Occurrence count, first/last seen, and a full-width trend line.
- Distributions across sources, pages, applications, OS, devices, countries, and languages.
- **Distinct examples**: a scrubber over the event's unique metadata payloads, each with the context of its latest occurrence and a session-trace link.
- The session traces the event occurred in.

Backed by `GET /api/v1/events?name=…&from=…&to=…&q=…` (dashboard filter vocabulary, so the detail covers the same slice as the panel that linked to it).

## Source-scoped exception groups

- An exception group's identity is now **source + fingerprint (type + normalized stack top)** rather than a project-wide fold: the inbox lists one row per application the failure was seen on (with the source label on the row), and the detail view is scoped via a required `?source=` parameter.
- **Triage is keyed per (project, fingerprint, source)** — the same fingerprint on two applications is two independent failures. There are no live datasets in the pre-source format, so no compatibility fallback is carried.
- Because the view names its source, **app versions render as bare version numbers** (`2.4.1` instead of `example.com @ 2.4.1`) — both in the distributions and the variant scrubber. Frames genuinely spanning multiple applications keep the qualified form.
- The **detail header is restructured**: status badge, bold exception type, and an exemplar message (e.g. *(unresolved)* **TypeError** `Cannot read properties of undefined (reading 'length')`) on one line; the trend line spans the info box's full width; the now-redundant sources card is dropped (the header names the source instead).
- **Triage controls are a segmented button group** floated top-right, offering only the transitions that apply to the group's current state: unresolved → resolve (green check) + mute (violet muted bell); resolved → reopen (white check struck through in red) + mute; muted → resolve + unmute (violet bell).

## Notes

- `merge_trends` (only used by the removed per-project fold) is gone, as is `ExceptionBreakdowns.sources`.
- The shared `distribution()` card moved to `ui/src/components/distribution.rs` so both detail pages use it; event pages tint the bars brand-teal rather than incident-red.
- New tests: event-name breakdown ranking/sentinels, event detail (variant collapse, distributions, traces, filter scoping), and version qualification across vs. within sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLoUjc29NaeLv5o25UAePe