### PR TITLE
Nest session-trace events under their page view

### DIFF
--- a/ui/src/components/_traces.scss
+++ b/ui/src/components/_traces.scss
@@ -361,6 +361,52 @@
   }
 }
 
+// A page view's activity span: the events and exceptions that fired while it
+// was open, matched by beacon id and nested under the page view. The brand rail
+// down its left edge reads as the page's lifetime — load at the top, exit at
+// the bottom — with each child event hanging from it.
+.trace-span {
+  position: relative;
+  margin: 0.5rem 0 0.15rem;
+  padding-left: 1.05rem;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 3px;
+    top: 0.1rem;
+    bottom: 0.4rem;
+    width: 2px;
+    border-radius: 1px;
+    background: linear-gradient(var(--brand-border), var(--brand-soft));
+  }
+}
+
+// The nested child timeline drops the card chrome and the neutral per-row rail:
+// the span's brand rail is the only spine at this level, and the child markers
+// hang from it. Their kind colours (event/exception) carry over unchanged.
+.trace-timeline--nested {
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+
+  .trace-entry {
+    padding: 0.35rem 0;
+
+    &::before {
+      display: none;
+    }
+
+    &__marker {
+      width: 7px;
+      height: 7px;
+      margin-top: 0.5rem;
+    }
+  }
+}
+
 @media (max-width: $bp-sm) {
   .trace-row__counts,
   .trace-row__open {

--- a/ui/src/pages/trace.rs
+++ b/ui/src/pages/trace.rs
@@ -1,7 +1,8 @@
 //! One session in forensic detail: the visit's context (source, client,
-//! locale, claimed release) and a vertical timeline of its page views, custom
-//! events, and exceptions, in arrival order. Page views fold their unload
-//! beacon in as a time-on-page badge.
+//! locale, claimed release) and a vertical timeline of its page views. Each
+//! page view spans from its load to its unload (a time-on-page badge), and the
+//! custom events and exceptions that fired while it was open — matched by
+//! beacon id — hang beneath it on a nested child timeline.
 
 use std::collections::{HashMap, HashSet};
 
@@ -120,9 +121,12 @@ fn summary_panel(trace: &SessionTraceData) -> Html {
     html! { <div class="panel trace-facts">{ for cells }</div> }
 }
 
-/// The vertical timeline. A page view's unload (matched by beacon id) is
-/// folded into the view's row as its time-on-page; unloads whose load fell
-/// outside the returned window still render on their own.
+/// The vertical timeline. Page views form the parent spine: each spans from its
+/// load to its unload (a time-on-page badge), matched by beacon id. The custom
+/// events and exceptions that share a page view's beacon id hang beneath it on a
+/// nested child timeline — so it reads at a glance which activity happened
+/// within which page view. Events whose page view fell outside the returned
+/// window (and unloads whose load did) still render on the parent spine.
 fn timeline(trace: &SessionTraceData) -> Html {
     let mut durations: HashMap<&str, i64> = HashMap::new();
     let mut loads: HashSet<&str> = HashSet::new();
@@ -140,21 +144,90 @@ fn timeline(trace: &SessionTraceData) -> Html {
         }
     }
 
+    // Bucket each page view's events/exceptions under its beacon id, preserving
+    // arrival order. Only events whose page view is present in this window are
+    // nested; the rest fall through to the parent spine as orphans.
+    let mut children: HashMap<&str, Vec<(usize, &TraceEvent)>> = HashMap::new();
+    for (i, event) in trace.events.iter().enumerate() {
+        if matches!(
+            event.kind,
+            TraceEventKind::Custom | TraceEventKind::Exception
+        ) && loads.contains(event.bid.as_str())
+        {
+            children
+                .entry(event.bid.as_str())
+                .or_default()
+                .push((i, event));
+        }
+    }
+
     let started = trace.started_ms;
     let rows = trace.events.iter().enumerate().filter_map(|(i, event)| {
-        // Fold paired unloads into their page view's row.
-        if event.kind == TraceEventKind::PageUnload && loads.contains(event.bid.as_str()) {
-            return None;
+        let paired = !event.bid.is_empty() && loads.contains(event.bid.as_str());
+        match event.kind {
+            TraceEventKind::PageLoad => {
+                let duration = durations.get(event.bid.as_str()).copied();
+                let kids = children.get(event.bid.as_str());
+                Some(page_view(event, started, duration, kids, i))
+            }
+            // Paired unloads and nested events are drawn within their page view.
+            TraceEventKind::PageUnload if paired => None,
+            TraceEventKind::Custom | TraceEventKind::Exception if paired => None,
+            // Orphans (page view outside the window) still get a parent row.
+            _ => Some(entry(event, started, event.duration_ms, i)),
         }
-        let duration = match event.kind {
-            TraceEventKind::PageLoad => durations.get(event.bid.as_str()).copied(),
-            TraceEventKind::PageUnload => event.duration_ms,
-            _ => None,
-        };
-        Some(entry(event, started, duration, i))
     });
 
     html! { <ol class="trace-timeline">{ for rows }</ol> }
+}
+
+/// A page view on the parent spine: its path and time-on-page span, with the
+/// events and exceptions that fired while it was open nested beneath it. The
+/// nested timeline is omitted entirely when the page view saw no such activity.
+fn page_view(
+    event: &TraceEvent,
+    started_ms: i64,
+    duration: Option<i64>,
+    children: Option<&Vec<(usize, &TraceEvent)>>,
+    index: usize,
+) -> Html {
+    let offset = event.received_ms - started_ms;
+    let nested = children.filter(|kids| !kids.is_empty()).map(|kids| {
+        let rows = kids.iter().map(|(i, ev)| entry(ev, started_ms, None, *i));
+        html! {
+            <div class="trace-span">
+                <ol class="trace-timeline trace-timeline--nested">{ for rows }</ol>
+            </div>
+        }
+    });
+
+    html! {
+        <li class={classes!("trace-entry", "trace-entry--page")} key={index.to_string()}>
+            <span class="trace-entry__marker" aria-hidden="true" />
+            <div class="trace-entry__body">
+                <div class="trace-entry__head">
+                    <span class="trace-entry__kind">{ "Page view" }</span>
+                    <span class="trace-entry__time" title={tooltip_label(event.received_ms, 0)}>
+                        { clock_time(event.received_ms) }
+                    </span>
+                    <span class="trace-entry__offset" title="Since the session started">
+                        { format!("+{}", format_duration(offset)) }
+                    </span>
+                </div>
+                <div class="trace-entry__line">
+                    <code class="trace-entry__path">
+                        { event.pathname.clone().unwrap_or_else(|| "/".into()) }
+                    </code>
+                    if let Some(duration) = duration {
+                        <span class="badge badge--muted" title="Time on page">
+                            { format!("{} on page", format_duration(duration)) }
+                        </span>
+                    }
+                </div>
+                { nested.unwrap_or_default() }
+            </div>
+        </li>
+    }
 }
 
 fn entry(event: &TraceEvent, started_ms: i64, duration: Option<i64>, index: usize) -> Html {


### PR DESCRIPTION
## What & why

On the session timeline, page views have a duration (load → unload) and the events/exceptions that fire during that window all carry the page view's **beacon id**. Previously every load, unload, event and exception rendered as a flat sequence of sibling rows, so you couldn't see *which* activity belonged to *which* page view.

This reworks the timeline into a two-level structure:

- **Parent spine** — one row per page view, showing its path and time-on-page span badge (unchanged fold-in of the paired unload).
- **Nested child timeline** — the custom events and exceptions that share a page view's beacon id hang beneath it, on a brand-tinted rail that reads as the page's lifetime. It's omitted entirely for page views with no activity.

Grouping is by beacon id (already present on every `TraceEvent`), so this is a **frontend-only change** — no API or query changes.

## Behaviour notes

- Events (and unloads) whose page view fell **outside the returned window** still render on the parent spine as before — nothing is dropped.
- Page views with no events/exceptions show just the page row + span badge (no empty nested block).
- Event/exception marker colours, metadata pills, context lists and stack traces are unchanged — they simply render one level in.

## Changes

- `ui/src/pages/trace.rs` — bucket events/exceptions by beacon id; new `page_view()` renderer wrapping a nested `trace-timeline`; `timeline()` now emits page views as parents and routes orphans to the spine.
- `ui/src/components/_traces.scss` — `.trace-span` (the page-lifetime rail) and `.trace-timeline--nested` (dropped card chrome + per-row rail, smaller child markers).

## Verification

- `cargo check --target wasm32-unknown-unknown` — clean.
- `cargo fmt --check` — clean.
- Rendered against a representative session (multiple page views, custom events, handled/unhandled exceptions, and a page view with no activity) to confirm nesting, span badges, and the empty case. Screenshots were shared during the working session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PM5jp5spfSijfzjf5suwnj