### PR TITLE
Fix polars `is_in` deprecation by imploding literal collections

### DIFF
--- a/agent/src/analytics/filter.rs
+++ b/agent/src/analytics/filter.rs
@@ -195,7 +195,10 @@ impl Compiler<'_> {
             .iter()
             .flat_map(|name| self.project_sources(name))
             .collect();
-        col("source").is_in(lit(Series::new("sources".into(), uris)).implode(false), false)
+        col("source").is_in(
+            lit(Series::new("sources".into(), uris)).implode(false),
+            false,
+        )
     }
 
     /// `column == value` with the language's semantics: case-insensitive, and
@@ -370,9 +373,10 @@ impl<'a> ExprVisitor<'a, Fold> for Compiler<'_> {
                 } else {
                     col(field.column).str().to_lowercase()
                 };
-                Ok(Node::Predicate(
-                    column.is_in(lit(Series::new("values".into(), values)).implode(false), false),
-                ))
+                Ok(Node::Predicate(column.is_in(
+                    lit(Series::new("values".into(), values)).implode(false),
+                    false,
+                )))
             }
 
             // ---- substrings / affixes -------------------------------------
@@ -477,10 +481,10 @@ fn source_in(values: &[String]) -> Expr {
             }
         })
         .collect();
-    col("source")
-        .str()
-        .to_lowercase()
-        .is_in(lit(Series::new("sources".into(), forms)).implode(false), false)
+    col("source").str().to_lowercase().is_in(
+        lit(Series::new("sources".into(), forms)).implode(false),
+        false,
+    )
 }
 
 /// Case-fold a column/needle pair for the case-insensitive operator variants.

--- a/agent/src/analytics/filter.rs
+++ b/agent/src/analytics/filter.rs
@@ -195,7 +195,7 @@ impl Compiler<'_> {
             .iter()
             .flat_map(|name| self.project_sources(name))
             .collect();
-        col("source").is_in(lit(Series::new("sources".into(), uris)), false)
+        col("source").is_in(lit(Series::new("sources".into(), uris)).implode(false), false)
     }
 
     /// `column == value` with the language's semantics: case-insensitive, and
@@ -371,7 +371,7 @@ impl<'a> ExprVisitor<'a, Fold> for Compiler<'_> {
                     col(field.column).str().to_lowercase()
                 };
                 Ok(Node::Predicate(
-                    column.is_in(lit(Series::new("values".into(), values)), false),
+                    column.is_in(lit(Series::new("values".into(), values)).implode(false), false),
                 ))
             }
 
@@ -480,7 +480,7 @@ fn source_in(values: &[String]) -> Expr {
     col("source")
         .str()
         .to_lowercase()
-        .is_in(lit(Series::new("sources".into(), forms)), false)
+        .is_in(lit(Series::new("sources".into(), forms)).implode(false), false)
 }
 
 /// Case-fold a column/needle pair for the case-insensitive operator variants.

--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -469,7 +469,7 @@ fn traces_of_occurrences(
         return Ok(Vec::new());
     }
     let sessions = combined(store, parquet_dir, from_ms, to_ms)?
-        .filter(col("sid").is_in(lit(Series::new("sids".into(), sids)), false));
+        .filter(col("sid").is_in(lit(Series::new("sids".into(), sids)).implode(false), false));
     recent_traces(sessions, TRACE_SAMPLE)
 }
 


### PR DESCRIPTION
## Summary

polars 0.54 deprecates `is_in` when the column and the collection it is tested against share the same nesting level, because the membership semantics become ambiguous (see [pola-rs/polars#22149](https://github.com/pola-rs/polars/issues/22149)). Every call site in the analytics query engine passed a flat `lit(Series::new(...))` whose dtype matches the column, so each one printed the following warning at query-execution time:

```
Deprecation: `is_in` with a collection of the same datatype is ambiguous and deprecated.
Please use `implode` to return to previous behavior.
```

The fix wraps each literal collection in `.implode(false)`, lifting it from a flat series to a single-row `List`. This makes the membership test unambiguous ("is the column value a member of this set") and restores the exact behavior polars applied implicitly, clearing the warning. `maintain_order` is `false` because order is irrelevant for a membership test.

## Changes

Four call sites updated — all mechanically identical:

- `agent/src/analytics/filter.rs`
  - `source_membership` — project-scoped source URI membership
  - the `in` / `in_cs` list operator lowering
  - `source_in` — bare-hostname source matching
- `agent/src/analytics/mod.rs`
  - `traces_of_occurrences` — session-id membership for trace sampling

## Verification

- `cargo build -p analytics` succeeds.
- `cargo test -p analytics --bins` — all 93 tests pass.
- Confirmed the warning before/after: on the base branch, a single executing test (`source_membership_selects_multiple_sources`) printed the deprecation warning twice; after the change the full suite runs with **zero** deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkQML6zWMSLDqxfayf7c9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkQML6zWMSLDqxfayf7c9Z)_