### PR TITLE
Derive tracker API from script src when data-api missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ The dashboard is served at the configured address (default `http://127.0.0.1:808
 
 ### Tracking a website
 
-Add the tracker script to your pages, pointing `data-api` at your server:
+Add the tracker script to your pages. It defaults to reporting back to the origin
+it was served from, so pointing `src` at your server is enough — set `data-api`
+explicitly only to override that host:
 
 ```html
 <script
   async
   src="https://analytics.example.com/tracker.js"
-  data-api="https://analytics.example.com"
   data-auto-capture-exceptions="true"
   data-app-version="1.4.2"
 ></script>

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -39,7 +39,7 @@ request because the page reads its JSON response.
 
 | Attribute                          | Effect                                                       |
 | ---------------------------------- | ------------------------------------------------------------ |
-| `data-api`                         | Collection host (defaults to the script's own origin).       |
+| `data-api`                         | Collection host (defaults to the origin the script's own `src` was served from). |
 | `data-auto-capture-exceptions`     | `"true"` to hook `window` errors and promise rejections.     |
 | `data-hash`                        | Treat URL-hash changes as navigations (hash-routed SPAs).    |
 

--- a/tracker/src/tracker.js
+++ b/tracker/src/tracker.js
@@ -8,7 +8,8 @@
 // stored id.
 //
 // Configured declaratively on the <script> tag:
-//   data-api="https://analytics.example.com"   collection host (default: same origin)
+//   data-api="https://analytics.example.com"   collection host (default: the origin
+//                                                the script's own src was served from)
 //   data-auto-capture-exceptions="true"          hook window errors + rejections
 //   data-hash                                    treat #hash changes as navigations
 //   data-app-version="1.4.2"                     attribute exceptions to a release
@@ -22,6 +23,20 @@ import { createExceptionReporter } from "./exceptions.js";
 
 function attr(el, name) {
   return el && el.getAttribute ? el.getAttribute(name) : null;
+}
+
+// Derive the collection host from the script's own src: a tracker served from
+// https://analytics.example.com/tracker.js defaults to posting beacons back to
+// that same origin. Returns "" (a same-origin relative base) when there is no
+// usable src, e.g. an inline script.
+function scriptOrigin(el) {
+  var src = el && el.src ? el.src : null;
+  if (!src) return "";
+  try {
+    return new URL(src).origin;
+  } catch (e) {
+    return "";
+  }
 }
 
 // A short random id: base36 timestamp + random suffix. Not collision-proof and not
@@ -66,7 +81,10 @@ export function init(overrides) {
   if (!doc || !win) return undefined;
 
   const script = overrides.script || doc.currentScript;
-  const api = overrides.api != null ? overrides.api : attr(script, "data-api") || "";
+  const api =
+    overrides.api != null
+      ? overrides.api
+      : attr(script, "data-api") || scriptOrigin(script);
   const captureExceptions =
     overrides.captureExceptions != null
       ? overrides.captureExceptions

--- a/tracker/test/tracker.test.js
+++ b/tracker/test/tracker.test.js
@@ -311,4 +311,17 @@ describe("init — public API", () => {
       "https://collect.example/track/ping",
     );
   });
+
+  it("derives the collection host from its own src when data-api is absent", async () => {
+    const script = document.createElement("script");
+    script.src = "https://collect.example/tracker.js";
+    document.body.appendChild(script);
+
+    init({ fetch: fetchMock, navigator: navMock, script });
+    await tick();
+
+    expect(getUrls(fetchMock, "/track/ping")[0]).toContain(
+      "https://collect.example/track/ping",
+    );
+  });
 });

--- a/ui/src/pages/settings.rs
+++ b/ui/src/pages/settings.rs
@@ -285,7 +285,7 @@ fn tracker_card() -> Html {
         .unwrap_or_else(|| "https://analytics.example.com".to_string());
 
     let snippet = format!(
-        "<script\n  async\n  src=\"{origin}/tracker.js\"\n  data-api=\"{origin}\"\n  data-auto-capture-exceptions=\"true\"\n></script>"
+        "<script\n  async\n  src=\"{origin}/tracker.js\"\n  data-auto-capture-exceptions=\"true\"\n></script>"
     );
 
     // navigator.clipboard only exists in secure contexts; on a plain-HTTP LAN


### PR DESCRIPTION
Make the tracker automatically use the origin the script was served from
as its collection host when the data-api attribute is not provided. This
lets users include a shorter installation snippet (only setting src) and
preserves empty-string behavior for inline scripts. Updated docs,
settings UI snippet, and tests to reflect the new default.

Changes:
- Add scriptOrigin helper in tracker/src/tracker.js and fall back to it when
data-api is omitted (preserving empty string for inline scripts).
- Shorten the install snippet in ui/src/pages/settings.rs and README files to
remove the now-redundant data-api line.
- Add a test in tracker/test/tracker.test.js asserting the collection host is
derived from the script src when data-api is absent.