### PR TITLE
Auto-unresolve regressed exceptions; split triage into resolution + suppression axes

### DIFF
--- a/agent/src/analytics/mod.rs
+++ b/agent/src/analytics/mod.rs
@@ -251,6 +251,8 @@ pub fn exception_groups_by_source(
                         first_seen_ms: first.get(i).unwrap_or(0),
                         last_seen_ms: last.get(i).unwrap_or(0),
                         status: ExceptionStatus::Unresolved,
+                        resolved: false,
+                        muted: false,
                         note: None,
                         trend: trend_of(list_i64(times, i).into_iter(), from_ms, to_ms),
                     },
@@ -336,6 +338,8 @@ pub fn exception_detail(
         first_seen_ms: received.get(height - 1).unwrap_or(0),
         last_seen_ms: received.get(0).unwrap_or(0),
         status: ExceptionStatus::Unresolved,
+        resolved: false,
+        muted: false,
         note: None,
         trend: trend_of((0..height).filter_map(|i| received.get(i)), from_ms, to_ms),
     };

--- a/agent/src/store/entities.rs
+++ b/agent/src/store/entities.rs
@@ -147,4 +147,44 @@ impl Store {
     pub fn get_triage(&self, project_id: &str, group_id: &str) -> Result<Option<ExceptionTriage>> {
         self.get_json(EXCEPTION_TRIAGE, &triage_key(project_id, group_id))
     }
+
+    /// Create-or-update a triage record in a single write transaction: `f` is
+    /// applied to the existing record, or to a fresh empty one when none exists,
+    /// then the result is persisted. Doing the read-modify-write under one
+    /// transaction keeps two concurrent edits (e.g. resolving and muting at once)
+    /// from clobbering each other's axis. Returns the stored record.
+    pub fn update_triage<F: FnOnce(&mut ExceptionTriage)>(
+        &self,
+        project_id: &str,
+        group_id: &str,
+        f: F,
+    ) -> Result<ExceptionTriage> {
+        let key = triage_key(project_id, group_id);
+        let txn = self.db.begin_write().or_system_err(STORAGE_ADVICE)?;
+        let updated = {
+            let mut table = txn
+                .open_table(EXCEPTION_TRIAGE)
+                .or_system_err(STORAGE_ADVICE)?;
+            let mut triage = match table.get(key.as_str()).or_system_err(STORAGE_ADVICE)? {
+                Some(value) => {
+                    serde_json::from_slice(value.value()).or_system_err(STORAGE_ADVICE)?
+                }
+                None => ExceptionTriage {
+                    resolved_at: None,
+                    muted_at: None,
+                    note: None,
+                    updated_at: Utc::now(),
+                    updated_by: None,
+                },
+            };
+            f(&mut triage);
+            let bytes = serde_json::to_vec(&triage).or_system_err(STORAGE_ADVICE)?;
+            table
+                .insert(key.as_str(), bytes.as_slice())
+                .or_system_err(STORAGE_ADVICE)?;
+            triage
+        };
+        txn.commit().or_system_err(STORAGE_ADVICE)?;
+        Ok(updated)
+    }
 }

--- a/agent/src/store/mod.rs
+++ b/agent/src/store/mod.rs
@@ -151,21 +151,68 @@ mod tests {
 
     #[test]
     fn triage_roundtrip() {
-        use analytics_api::ExceptionStatus;
         let store = temp_store();
+        let resolved_at = Utc::now();
         let triage = ExceptionTriage {
-            status: ExceptionStatus::Resolved,
+            resolved_at: Some(resolved_at),
+            muted_at: None,
             note: Some("fixed in v2".to_string()),
-            updated_at: Utc::now(),
+            updated_at: resolved_at,
             updated_by: Some("admin".to_string()),
         };
         store.put_triage("p1", "g1", &triage).unwrap();
         let got = store.get_triage("p1", "g1").unwrap().unwrap();
-        assert_eq!(got.status, ExceptionStatus::Resolved);
+        assert_eq!(got.resolved_at, Some(resolved_at));
         assert_eq!(got.note.as_deref(), Some("fixed in v2"));
         // A different group, or different project, has no triage.
         assert!(store.get_triage("p1", "other").unwrap().is_none());
         assert!(store.get_triage("p2", "g1").unwrap().is_none());
+    }
+
+    #[test]
+    fn update_triage_upserts_and_keeps_axes_independent() {
+        let store = temp_store();
+        // The first update creates the record and resolves it.
+        store
+            .update_triage("p1", "g1", |t| {
+                t.resolved_at = Some(Utc::now());
+                t.note = Some("first".to_string());
+            })
+            .unwrap();
+        // Muting must not disturb the resolution axis or the note.
+        let muted = store
+            .update_triage("p1", "g1", |t| t.muted_at = Some(Utc::now()))
+            .unwrap();
+        assert!(muted.resolved_at.is_some(), "resolution preserved");
+        assert!(muted.muted_at.is_some(), "now muted");
+        assert_eq!(muted.note.as_deref(), Some("first"), "note preserved");
+    }
+
+    #[test]
+    fn resolution_regresses_on_a_later_occurrence() {
+        let resolved_at = Utc::now();
+        let triage = ExceptionTriage {
+            resolved_at: Some(resolved_at),
+            muted_at: None,
+            note: None,
+            updated_at: resolved_at,
+            updated_by: None,
+        };
+        let anchor = resolved_at.timestamp_millis();
+        // Occurrences up to the anchor keep it resolved…
+        assert!(triage.is_resolved(anchor));
+        assert!(triage.is_resolved(anchor - 1));
+        // …a later one is a regression, surfacing as unresolved again.
+        assert!(!triage.is_resolved(anchor + 1));
+        assert!(!triage.is_muted());
+        // Muting is independent of resolution and of recurrence.
+        let muted = ExceptionTriage {
+            muted_at: Some(resolved_at),
+            resolved_at: None,
+            ..triage
+        };
+        assert!(muted.is_muted());
+        assert!(!muted.is_resolved(anchor + 1));
     }
 
     #[test]

--- a/agent/src/store/schema.rs
+++ b/agent/src/store/schema.rs
@@ -4,14 +4,19 @@
 //! any pending migration steps in order. A database newer than this build is
 //! rejected rather than silently misread.
 
-use redb::{Database, ReadableDatabase};
+use chrono::{DateTime, Utc};
+use redb::{Database, ReadableDatabase, ReadableTable};
+use serde::Deserialize;
 
-use super::tables::{META, META_SCHEMA_VERSION, OPEN_ADVICE, STORAGE_ADVICE, u32_from_be};
+use super::tables::{
+    EXCEPTION_TRIAGE, META, META_SCHEMA_VERSION, OPEN_ADVICE, STORAGE_ADVICE, u32_from_be,
+};
+use super::triage::ExceptionTriage;
 use crate::errors::{Result, ResultExt};
 
 /// The current on-disk schema version. Bump this and add an [`apply`] arm whenever
 /// the stored layout changes incompatibly.
-pub(super) const SCHEMA_VERSION: u32 = 1;
+pub(super) const SCHEMA_VERSION: u32 = 2;
 
 /// Ensure the database is at [`SCHEMA_VERSION`], applying migrations in order.
 pub(super) fn migrate(db: &Database) -> Result<()> {
@@ -44,17 +49,72 @@ pub(super) fn migrate(db: &Database) -> Result<()> {
 }
 
 /// Apply the migration that brings the store *to* `version`.
-fn apply(_db: &Database, version: u32) -> Result<()> {
+fn apply(db: &Database, version: u32) -> Result<()> {
     match version {
         // v1 is the initial schema; there is nothing to migrate from an empty store
         // beyond stamping the version (handled by the caller).
         1 => Ok(()),
-        // Future migrations slot in here, e.g. `2 => migrate_v2(_db),`.
+        // v2 splits the single exception-triage `status` into two independent
+        // axes: a `resolved_at` anchor (the sole source of truth for resolution,
+        // so a later occurrence reopens the group automatically) and a `muted_at`
+        // suppression flag.
+        2 => migrate_triage_to_axes(db),
         other => Err(human_errors::system(
             format!("No migration is defined for schema version {other}."),
             &["This is a bug; please report it with the server version."],
         )),
     }
+}
+
+/// The pre-v2 triage record: a single collapsed `status`.
+#[derive(Deserialize)]
+struct LegacyTriage {
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    note: Option<String>,
+    updated_at: DateTime<Utc>,
+    #[serde(default)]
+    updated_by: Option<String>,
+}
+
+/// Rewrite every triage record from the collapsed `status` to the resolution +
+/// suppression axes. A `resolved` record's `updated_at` was when it was resolved,
+/// so it becomes the `resolved_at` anchor; likewise `ignored` becomes `muted_at`.
+fn migrate_triage_to_axes(db: &Database) -> Result<()> {
+    let txn = db.begin_write().or_system_err(STORAGE_ADVICE)?;
+    {
+        let mut table = txn
+            .open_table(EXCEPTION_TRIAGE)
+            .or_system_err(STORAGE_ADVICE)?;
+        let mut rewrites: Vec<(String, Vec<u8>)> = Vec::new();
+        for item in table.iter().or_system_err(STORAGE_ADVICE)? {
+            let (key, value) = item.or_system_err(STORAGE_ADVICE)?;
+            let legacy: LegacyTriage =
+                serde_json::from_slice(value.value()).or_system_err(STORAGE_ADVICE)?;
+            let (resolved_at, muted_at) = match legacy.status.as_str() {
+                "resolved" => (Some(legacy.updated_at), None),
+                "ignored" => (None, Some(legacy.updated_at)),
+                _ => (None, None),
+            };
+            let migrated = ExceptionTriage {
+                resolved_at,
+                muted_at,
+                note: legacy.note,
+                updated_at: legacy.updated_at,
+                updated_by: legacy.updated_by,
+            };
+            let bytes = serde_json::to_vec(&migrated).or_system_err(STORAGE_ADVICE)?;
+            rewrites.push((key.value().to_string(), bytes));
+        }
+        for (key, bytes) in rewrites {
+            table
+                .insert(key.as_str(), bytes.as_slice())
+                .or_system_err(STORAGE_ADVICE)?;
+        }
+    }
+    txn.commit().or_system_err(STORAGE_ADVICE)?;
+    Ok(())
 }
 
 fn read_version(db: &Database) -> Result<u32> {
@@ -122,6 +182,62 @@ mod tests {
         write_version(&db, SCHEMA_VERSION + 1).unwrap();
         let err = migrate(&db).unwrap_err();
         assert!(err.to_string().contains("schema"));
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn v2_splits_triage_status_into_axes() {
+        use super::super::tables::{EXCEPTION_TRIAGE, triage_key};
+        let (db, path) = temp_db();
+        // Seed pre-v2 records carrying the collapsed `status`.
+        write_version(&db, 1).unwrap();
+        let updated_at = Utc::now();
+        let legacy = |status: &str| {
+            serde_json::json!({
+                "status": status,
+                "note": "n",
+                "updated_at": updated_at,
+                "updated_by": "admin",
+            })
+            .to_string()
+        };
+        {
+            let txn = db.begin_write().unwrap();
+            {
+                let mut t = txn.open_table(EXCEPTION_TRIAGE).unwrap();
+                t.insert(triage_key("p", "res").as_str(), legacy("resolved").as_bytes())
+                    .unwrap();
+                t.insert(triage_key("p", "ign").as_str(), legacy("ignored").as_bytes())
+                    .unwrap();
+                t.insert(triage_key("p", "unr").as_str(), legacy("unresolved").as_bytes())
+                    .unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        migrate(&db).unwrap();
+        assert_eq!(read_version(&db).unwrap(), SCHEMA_VERSION);
+
+        let read = |key: String| -> ExceptionTriage {
+            let txn = db.begin_read().unwrap();
+            let t = txn.open_table(EXCEPTION_TRIAGE).unwrap();
+            let v = t.get(key.as_str()).unwrap().unwrap();
+            serde_json::from_slice(v.value()).unwrap()
+        };
+
+        let res = read(triage_key("p", "res"));
+        assert_eq!(res.resolved_at, Some(updated_at), "resolved anchors at updated_at");
+        assert!(res.muted_at.is_none());
+        assert_eq!(res.note.as_deref(), Some("n"), "note preserved");
+
+        let ign = read(triage_key("p", "ign"));
+        assert_eq!(ign.muted_at, Some(updated_at), "ignored becomes muted");
+        assert!(ign.resolved_at.is_none());
+
+        let unr = read(triage_key("p", "unr"));
+        assert!(unr.resolved_at.is_none() && unr.muted_at.is_none());
+
         drop(db);
         let _ = std::fs::remove_file(&path);
     }

--- a/agent/src/store/triage.rs
+++ b/agent/src/store/triage.rs
@@ -1,13 +1,40 @@
-use analytics_api::ExceptionStatus;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Admin-set triage state for an exception group, keyed by `(project_id, group_id)`.
 /// This is the only mutable exception state; occurrences are append-only events.
+///
+/// Resolution and suppression are two independent axes:
+/// - `resolved_at` is the sole source of truth for resolution. A group counts as
+///   resolved only while its most recent occurrence predates it — an occurrence
+///   *after* `resolved_at` is a regression, so the group surfaces as unresolved
+///   again automatically (see [`ExceptionTriage::is_resolved`]).
+/// - `muted_at` suppresses a group independently of whether it is resolved; a
+///   recurrence never lifts it (muting is a deliberate "stop showing me this").
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExceptionTriage {
-    pub status: ExceptionStatus,
+    #[serde(default)]
+    pub resolved_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub muted_at: Option<DateTime<Utc>>,
     pub note: Option<String>,
     pub updated_at: DateTime<Utc>,
     pub updated_by: Option<String>,
+}
+
+impl ExceptionTriage {
+    /// Whether the group is currently resolved: it was resolved at some point and
+    /// has not been seen again since. `last_seen_ms` is the group's most recent
+    /// occurrence within the viewed window; a newer occurrence is a regression and
+    /// reopens the group without any write.
+    pub fn is_resolved(&self, last_seen_ms: i64) -> bool {
+        self.resolved_at
+            .is_some_and(|at| last_seen_ms <= at.timestamp_millis())
+    }
+
+    /// Whether the group is suppressed. Independent of resolution and unaffected
+    /// by recurrence.
+    pub fn is_muted(&self) -> bool {
+        self.muted_at.is_some()
+    }
 }

--- a/agent/src/web/api/exceptions.rs
+++ b/agent/src/web/api/exceptions.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 
 use actix_web::http::StatusCode;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, web};
-use analytics_api::{ExceptionGroupDetail, GlobalException, TriageInput, pixel_source};
+use analytics_api::{
+    ExceptionGroupDetail, ExceptionStatus, GlobalException, TriageInput, pixel_source,
+};
 use chrono::Utc;
 use serde::Deserialize;
 use tracing_batteries::prelude::*;
@@ -14,7 +16,6 @@ use super::query::resolve_range;
 use super::{Authenticated, internal_error, json_error};
 use crate::analytics::{self, filter::FieldSet};
 use crate::state::AppState;
-use crate::store::ExceptionTriage;
 
 const VARIANT_LIMIT: usize = 50;
 
@@ -94,7 +95,9 @@ pub async fn list_all(
                 if let Some(triage) =
                     store.get_triage(pid, &scoped_group(&group.group_id, &source))?
                 {
-                    group.status = triage.status;
+                    group.resolved = triage.is_resolved(group.last_seen_ms);
+                    group.muted = triage.is_muted();
+                    group.status = ExceptionStatus::from(&group);
                     group.note = triage.note;
                 }
                 project_name = project_names.get(pid).cloned();
@@ -178,7 +181,9 @@ pub async fn detail(
             if let Some(triage) =
                 store.get_triage(&project_id, &scoped_group(&group_id, &source))?
             {
-                detail.group.status = triage.status;
+                detail.group.resolved = triage.is_resolved(detail.group.last_seen_ms);
+                detail.group.muted = triage.is_muted();
+                detail.group.status = ExceptionStatus::from(&detail.group);
                 detail.group.note = triage.note;
             }
             Ok(Some(detail))
@@ -200,7 +205,12 @@ pub async fn detail(
     }
 }
 
-/// `PATCH /api/v1/exceptions/{group_id}` — set the triage status/note for a group.
+/// `PATCH /api/v1/exceptions/{group_id}` — update a group's triage axes.
+///
+/// Resolution and suppression are independent: a field left `None` on the input
+/// is left unchanged, so the inbox's separate Resolve/Reopen and Mute/Unmute
+/// controls each touch only their own axis. Resolving anchors `resolved_at` at
+/// now, which is what lets a later occurrence reopen the group automatically.
 pub async fn triage(
     req: HttpRequest,
     state: web::Data<AppState>,
@@ -214,23 +224,33 @@ pub async fn triage(
         .get::<Authenticated>()
         .and_then(|a| a.user.as_ref().map(|u| u.name.clone()));
 
-    let triage = ExceptionTriage {
-        status: input.status,
-        note: input.note.filter(|n| !n.trim().is_empty()),
-        updated_at: Utc::now(),
-        updated_by,
-    };
-
     let source = input.source.trim();
     if source.is_empty() {
         return json_error(StatusCode::BAD_REQUEST, "A source is required.");
     }
 
-    match state
-        .store
-        .put_triage(&input.project_id, &scoped_group(&group_id, source), &triage)
-    {
-        Ok(()) => HttpResponse::NoContent().finish(),
+    match state.store.update_triage(
+        &input.project_id,
+        &scoped_group(&group_id, source),
+        |triage| {
+            let now = Utc::now();
+            if let Some(resolved) = input.resolved {
+                // Anchor resolution at now; reopening clears the anchor.
+                triage.resolved_at = resolved.then_some(now);
+            }
+            if let Some(muted) = input.muted {
+                triage.muted_at = muted.then_some(now);
+            }
+            // A note is only touched when the caller sends one, so toggling an
+            // axis never wipes an existing note; an empty note clears it.
+            if let Some(note) = input.note {
+                triage.note = Some(note).filter(|n| !n.trim().is_empty());
+            }
+            triage.updated_at = now;
+            triage.updated_by = updated_by;
+        },
+    ) {
+        Ok(_) => HttpResponse::NoContent().finish(),
         Err(err) => internal_error(err),
     }
 }

--- a/api/src/exception.rs
+++ b/api/src/exception.rs
@@ -2,8 +2,11 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// The triage status of an exception group, set by an administrator. Stored
-/// separately from the (append-only) occurrence stream.
+/// The collapsed, display-oriented triage status of an exception group, derived
+/// from the two independent triage axes (resolution and suppression). Muting takes
+/// precedence, so a muted group reads as `Ignored` regardless of whether it is also
+/// resolved; the raw axes travel alongside it on [`ExceptionGroup`] for controls
+/// that need to act on each independently (see [`ExceptionStatus::from`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ExceptionStatus {
@@ -76,13 +79,36 @@ pub struct ExceptionGroup {
     pub count: i64,
     pub first_seen_ms: i64,
     pub last_seen_ms: i64,
+    /// The collapsed display status ([`ExceptionStatus::derive`] of the two axes
+    /// below), for the inbox badge and status tabs.
     pub status: ExceptionStatus,
+    /// Whether the group is currently resolved. A group resolved in the past but
+    /// seen again since counts as unresolved here (a regression reopens it).
+    #[serde(default)]
+    pub resolved: bool,
+    /// Whether the group is suppressed. Orthogonal to `resolved`.
+    #[serde(default)]
+    pub muted: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     /// Occurrence counts over the query range, split into [`TREND_BUCKETS`]
     /// equal buckets (oldest first), for the frequency sparkline.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trend: Vec<i64>,
+}
+
+/// Collapse a group's two orthogonal triage axes into its single display status.
+/// Suppression wins: a muted group is `Ignored` even when it is also resolved.
+impl From<&ExceptionGroup> for ExceptionStatus {
+    fn from(group: &ExceptionGroup) -> Self {
+        if group.muted {
+            Self::Ignored
+        } else if group.resolved {
+            Self::Resolved
+        } else {
+            Self::Unresolved
+        }
+    }
 }
 
 /// A distinct example within an exception group: occurrences sharing the same
@@ -165,10 +191,20 @@ pub struct GlobalException {
 /// Payload for updating an exception group's triage state. Triage is scoped to
 /// the group's source — the same fingerprint on two applications is two
 /// independent failures.
+///
+/// Resolution and suppression are independent axes; a field left `None` is left
+/// unchanged, so a control can toggle one axis without disturbing the other.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriageInput {
     pub project_id: String,
-    pub status: ExceptionStatus,
+    /// Set the resolution axis: `Some(true)` resolves (anchored at now),
+    /// `Some(false)` reopens, `None` leaves it unchanged.
+    #[serde(default)]
+    pub resolved: Option<bool>,
+    /// Set the suppression axis: `Some(true)` mutes, `Some(false)` unmutes,
+    /// `None` leaves it unchanged.
+    #[serde(default)]
+    pub muted: Option<bool>,
     #[serde(default)]
     pub note: Option<String>,
     /// The source URI the triaged group was seen on.
@@ -198,5 +234,40 @@ mod tests {
     #[test]
     fn empty_message_yields_empty_summary() {
         assert_eq!(summary_line("   \n  \n"), "");
+    }
+
+    #[test]
+    fn status_derives_from_axes_with_mute_precedence() {
+        use super::{ExceptionGroup, ExceptionStatus};
+        let group = |resolved: bool, muted: bool| ExceptionGroup {
+            group_id: "g".into(),
+            exc_type: "T".into(),
+            sample_message: "m".into(),
+            count: 1,
+            first_seen_ms: 0,
+            last_seen_ms: 0,
+            status: ExceptionStatus::Unresolved,
+            resolved,
+            muted,
+            note: None,
+            trend: Vec::new(),
+        };
+        assert_eq!(
+            ExceptionStatus::from(&group(false, false)),
+            ExceptionStatus::Unresolved
+        );
+        assert_eq!(
+            ExceptionStatus::from(&group(true, false)),
+            ExceptionStatus::Resolved
+        );
+        assert_eq!(
+            ExceptionStatus::from(&group(false, true)),
+            ExceptionStatus::Ignored
+        );
+        // Suppression wins even when the group is also resolved.
+        assert_eq!(
+            ExceptionStatus::from(&group(true, true)),
+            ExceptionStatus::Ignored
+        );
     }
 }

--- a/ui/src/components/status.rs
+++ b/ui/src/components/status.rs
@@ -7,7 +7,7 @@ pub fn status_label(status: ExceptionStatus) -> &'static str {
     match status {
         ExceptionStatus::Unresolved => "Unresolved",
         ExceptionStatus::Resolved => "Resolved",
-        ExceptionStatus::Ignored => "Ignored",
+        ExceptionStatus::Ignored => "Muted",
     }
 }
 

--- a/ui/src/pages/exception_detail.rs
+++ b/ui/src/pages/exception_detail.rs
@@ -9,7 +9,7 @@
 //! state.
 
 use analytics_api::{
-    ExceptionGroupDetail, ExceptionStatus, ExceptionVariant, TriageInput, source_label,
+    ExceptionGroupDetail, ExceptionVariant, TriageInput, source_label,
 };
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -71,17 +71,20 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
         );
     }
 
-    let set_status = {
+    let set_axis = {
         let (project, group, source, reload) = (
             project.clone(),
             group.clone(),
             source.clone(),
             reload.clone(),
         );
-        move |status: ExceptionStatus| {
+        // Build a click handler that flips a single triage axis, leaving the
+        // other one untouched (a `None` field is left unchanged server-side).
+        move |resolved: Option<bool>, muted: Option<bool>| {
             let input = TriageInput {
                 project_id: project.clone(),
-                status,
+                resolved,
+                muted,
                 note: None,
                 source: source.clone().unwrap_or_default(),
             };
@@ -100,65 +103,56 @@ pub fn exception_detail(props: &ExceptionDetailProps) -> Html {
     let header_actions = match (&source, &*detail) {
         (Some(_), Some(Ok(detail))) => {
             let status = detail.group.status;
-            // Colour + glyph carry the verb. Only the transitions that apply
-            // to the current state are offered: an open group can be resolved
-            // or muted; a triaged one reopened (or re-routed to the other
-            // triaged state).
-            let action =
-                |target: ExceptionStatus, class: &'static str, label: &'static str, icon: Html| {
-                    html! {
-                        <button
-                            class={classes!("exc-action", class)}
-                            title={label}
-                            aria-label={label}
-                            onclick={set_status(target)}
-                        >
-                            { icon }
-                        </button>
-                    }
-                };
-            let resolve = || {
-                action(
-                    ExceptionStatus::Resolved,
-                    "exc-action--resolve",
-                    "Mark resolved",
-                    icons::check(),
-                )
+            let button = |class: &'static str, label: &'static str, icon: Html, onclick| {
+                html! {
+                    <button
+                        class={classes!("exc-action", class)}
+                        title={label}
+                        aria-label={label}
+                        onclick={onclick}
+                    >
+                        { icon }
+                    </button>
+                }
             };
-            let mute = || {
-                action(
-                    ExceptionStatus::Ignored,
-                    "exc-action--ignore",
-                    "Mute",
-                    icons::mute(),
-                )
-            };
-            let reopen = || {
-                action(
-                    ExceptionStatus::Unresolved,
+            // Two independent controls: resolution and suppression. Each reflects
+            // its own axis, so a group can be (e.g.) resolved *and* muted at once.
+            let resolution = if detail.group.resolved {
+                button(
                     "exc-action--reopen",
                     "Reopen",
                     icons::check_struck(),
+                    set_axis(Some(false), None),
+                )
+            } else {
+                button(
+                    "exc-action--resolve",
+                    "Mark resolved",
+                    icons::check(),
+                    set_axis(Some(true), None),
                 )
             };
-            let unmute = || {
-                action(
-                    ExceptionStatus::Unresolved,
+            let suppression = if detail.group.muted {
+                button(
                     "exc-action--ignore",
                     "Unmute",
                     icons::bell(),
+                    set_axis(None, Some(false)),
                 )
-            };
-            let actions = match status {
-                ExceptionStatus::Unresolved => html! { <>{ resolve() }{ mute() }</> },
-                ExceptionStatus::Resolved => html! { <>{ reopen() }{ mute() }</> },
-                ExceptionStatus::Ignored => html! { <>{ resolve() }{ unmute() }</> },
+            } else {
+                button(
+                    "exc-action--ignore",
+                    "Mute",
+                    icons::mute(),
+                    set_axis(None, Some(true)),
+                )
             };
             html! {
                 <>
                     <span class={status_class(status)}>{ status_label(status) }</span>
                     <div class="exc-head__actions" role="group" aria-label="Triage">
-                        { actions }
+                        { resolution }
+                        { suppression }
                     </div>
                 </>
             }

--- a/ui/src/pages/exceptions.rs
+++ b/ui/src/pages/exceptions.rs
@@ -50,7 +50,7 @@ impl StatusTab {
         match self {
             StatusTab::Unresolved => "Unresolved",
             StatusTab::Resolved => "Resolved",
-            StatusTab::Ignored => "Ignored",
+            StatusTab::Ignored => "Muted",
             StatusTab::All => "All",
         }
     }


### PR DESCRIPTION
## Summary

Resolved exception groups that are detected again now **un-resolve automatically** (a Sentry-style regression), and triage is redesigned so **resolution** and **suppression** are two independent axes instead of one conflated three-state `status`.

Previously a group's triage was a single `status` (`Unresolved`/`Resolved`/`Ignored`), and a resolved group silently kept accumulating occurrences forever — an operator had to manually reopen it. This conflated "is it fixed?" with "am I muting it?", and had two sources of truth for resolution once we wanted regression detection.

## Design

- **Resolution has a single source of truth: `resolved_at`.** A group counts as resolved only while its most recent occurrence predates that anchor — an occurrence *after* `resolved_at` is a regression, so it surfaces as unresolved again. This is a pure read-time derivation (`ExceptionTriage::is_resolved(last_seen_ms)`), so the append-only ingest hot path is untouched — no extra work per event.
- **Suppression is independent: `muted_at`.** Muting is orthogonal to resolution and is never lifted by recurrence (muting is a deliberate "stop showing me this"). A group can be resolved *and* muted at once.
- **Only `Resolved` auto-reopens**; muted groups stay muted on recurrence.

## API

- `ExceptionGroup` now carries derived `resolved` and `muted` booleans. The existing 3-variant `ExceptionStatus` remains as a collapsed display value, derived via `impl From<&ExceptionGroup>` (suppression takes precedence → `Ignored`), for the inbox badge and status tabs.
- `TriageInput` replaces `status` with per-axis intents `resolved: Option<bool>` / `muted: Option<bool>` (a `None` field is left unchanged), so a control can toggle one axis without disturbing the other. The `PATCH` handler is now a transactional read-modify-write, which also fixes notes being wiped on every toggle.

## Storage & migration

- `ExceptionTriage` stores `resolved_at`/`muted_at` timestamps instead of `status`.
- **Schema v2 migration** rewrites existing triage records: `resolved → resolved_at = updated_at`, `ignored → muted_at = updated_at`, `unresolved → both cleared`. Existing resolved groups become regression-aware immediately.

## UI

- Exception detail page now shows **two independent toggles** — Resolve/Reopen and Mute/Unmute — replacing the state-dependent action set.
- Inbox "Ignored" tab/badge relabeled **"Muted"** for consistency with the Mute action; muted groups stay out of the resolution tabs.

## Testing

- New/updated unit tests: `is_resolved` regression boundary, `is_muted`, independent-axis `update_triage` upsert, the v2 migration mapping, and `ExceptionStatus` derivation precedence.
- Full backend suite passes (132 tests); `cargo clippy` clean on touched files; UI type-checks and is clippy-clean for `wasm32-unknown-unknown`.

## Notes

- No new dependencies; no ingest-path changes.
- Backward compatible: the migration is forward-only and preserves notes/`updated_at`/`updated_by`.