### PR TITLE
feat: Add /robots.txt endpoint

### DIFF
--- a/agent/src/web/track/mod.rs
+++ b/agent/src/web/track/mod.rs
@@ -4,6 +4,7 @@ mod exception;
 mod gif;
 mod hit;
 mod ping;
+mod robots;
 mod tracker;
 
 use actix_cors::Cors;
@@ -18,9 +19,10 @@ use crate::state::AppState;
 /// 2 MB default to limit the work an unauthenticated flood can force.
 const MAX_TRACK_BODY: usize = 16 * 1024;
 
-/// Register `/tracker.js` and the CORS-enabled `/track/*` endpoints.
+/// Register `/tracker.js`, `/robots.txt`, and the CORS-enabled `/track/*` endpoints.
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.route("/tracker.js", web::get().to(tracker::tracker_js))
+        .route("/robots.txt", web::get().to(robots::robots_txt))
         .service(
             // Beacons are sent cross-origin from tracked sites. Hits and exceptions are
             // posted as `text/plain` so they are CORS "simple requests" (no preflight) and

--- a/agent/src/web/track/robots.rs
+++ b/agent/src/web/track/robots.rs
@@ -1,0 +1,16 @@
+//! `GET /robots.txt` — crawler directives.
+//!
+//! This service is an analytics backend and private dashboard; there is nothing
+//! useful for search engines to index, so we ask well-behaved crawlers to stay out.
+
+use actix_web::HttpResponse;
+use actix_web::http::header::CACHE_CONTROL;
+
+const ROBOTS_TXT: &str = "User-agent: *\nDisallow: /\n";
+
+pub async fn robots_txt() -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/plain; charset=utf-8")
+        .insert_header((CACHE_CONTROL, "public, max-age=86400"))
+        .body(ROBOTS_TXT)
+}


### PR DESCRIPTION
Adds a `GET /robots.txt` handler serving a static `User-agent: * / Disallow: /` response (text/plain, 1-day cache). Registered in `track::configure` so it wins before the SPA `default_service` fallback, which previously served `index.html` for `/robots.txt`.

Unauthenticated, outside the `/track` CORS scope, mirrors the existing `/tracker.js` static handler.